### PR TITLE
[Feat] 연간·월간·주간 계획서 작성 및 업로드 기능 추가

### DIFF
--- a/src/main/java/org/example/dndn/workplan/WorkPlanRepository.java
+++ b/src/main/java/org/example/dndn/workplan/WorkPlanRepository.java
@@ -1,9 +1,9 @@
 package org.example.dndn.workplan;
 
-import org.example.dndn.workplan.model.PlanStatus;
-import org.example.dndn.workplan.model.PlanType;
-import org.example.dndn.workplan.model.WorkPlan;
-import org.example.dndn.workplan.model.WorkTrade;
+import org.example.dndn.workplan.model.enums.PlanStatus;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.enums.WorkTrade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -17,4 +17,11 @@ public interface WorkPlanRepository extends JpaRepository<WorkPlan, Long> {
     List<WorkPlan> findAllByPlanTypeAndStatus(PlanType planType, PlanStatus status);
 
     List<WorkPlan> findAllByPlanTypeAndTradeAndStatus(PlanType planType, WorkTrade trade, PlanStatus status);
+
+    // AnalysisService — 현장 기준 WorkPlan 조회
+    // WorkPlan → tradeProcess → masterSchedule → project 경로
+    List<WorkPlan> findAllByTradeProcess_MasterSchedule_Project_Idx(Long projectId);
+
+    // AnalysisService — 특정 TradeProcess에 연결된 WorkPlan 조회
+    List<WorkPlan> findAllByTradeProcess_Idx(Long tradeProcessId);
 }

--- a/src/main/java/org/example/dndn/workplan/WorkPlanService.java
+++ b/src/main/java/org/example/dndn/workplan/WorkPlanService.java
@@ -1,17 +1,15 @@
 package org.example.dndn.workplan;
 
 import lombok.RequiredArgsConstructor;
-import org.example.dndn.workplan.model.PlanStatus;
-import org.example.dndn.workplan.model.PlanType;
-import org.example.dndn.workplan.model.WorkPlan;
-import org.example.dndn.workplan.model.WorkPlanDto;
-import org.example.dndn.workplan.model.WorkPlanEquipment;
-import org.example.dndn.workplan.model.WorkPlanExtension;
-import org.example.dndn.workplan.model.WorkPlanWorker;
-import org.example.dndn.workplan.model.WorkTrade;
+import org.example.dndn.project.repository.TradeProcessRepository;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.workplan.model.*;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.entity.WorkPlanExtension;
+import org.example.dndn.workplan.model.enums.PlanStatus;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.example.dndn.workplan.model.enums.WorkTrade;
 import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -25,21 +23,24 @@ import java.util.List;
 public class WorkPlanService {
 
     private final WorkPlanRepository workPlanRepository;
+    // ── 1단계 추가 ─────────────────────────────────────────────────────────
+    private final TradeProcessRepository tradeProcessRepository;
+    // ────────────────────────────────────────────────────────────────────────
 
     // 작업 계획 등록
     @Transactional
     public Long create(WorkPlanDto.Req dto) {
         WorkPlan plan = dto.toEntity();
-        WorkPlan savedPlan = workPlanRepository.save(plan);
 
-        return savedPlan.getIdx();
+        linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
+        linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
+
+        return workPlanRepository.save(plan).getIdx();
     }
 
     // 작업 계획 단일 조회
     public WorkPlanDto.Res read(Long planId) {
-        WorkPlan plan = findPlan(planId);
-
-        return WorkPlanDto.Res.from(plan);
+        return WorkPlanDto.Res.from(findPlan(planId));
     }
 
     // 작업 계획 목록 조회 (계획 종류 + 공종/상태 필터)
@@ -47,11 +48,9 @@ public class WorkPlanService {
         PlanType type = PlanType.fromLabel(planType);
         WorkTrade tradeEnum = WorkTrade.fromLabel(trade);
         PlanStatus statusEnum = (status == null || status.isBlank())
-                ? null
-                : PlanStatus.fromLabel(status);
+                ? null : PlanStatus.fromLabel(status);
 
         List<WorkPlan> plans;
-
         if (tradeEnum != null && statusEnum != null) {
             plans = workPlanRepository.findAllByPlanTypeAndTradeAndStatus(type, tradeEnum, statusEnum);
         } else if (tradeEnum != null) {
@@ -62,13 +61,10 @@ public class WorkPlanService {
             plans = workPlanRepository.findAllByPlanType(type);
         }
 
-        return plans.stream()
-                .map(WorkPlanDto.workPlanRes::from)
-                .toList();
+        return plans.stream().map(WorkPlanDto.workPlanRes::from).toList();
     }
 
     // 작업 계획 정보 수정
-    // requiredCount는 받지 않음 - workers로부터 자동 계산됨
     @Transactional
     public void update(Long planId, WorkPlanDto.Req dto) {
         WorkPlan plan = findPlan(planId);
@@ -89,23 +85,23 @@ public class WorkPlanService {
         if (dto.getWorkers() != null) {
             plan.replaceWorkers(dto.getWorkers().stream()
                     .filter(w -> w != null && w.getTrade() != null && !w.getTrade().isBlank())
-                    .map(WorkPlanDto.WorkerEntry::toEntity)
-                    .toList());
+                    .map(WorkPlanDto.WorkerEntry::toEntity).toList());
         }
 
         if (dto.getEquipment() != null) {
             plan.replaceEquipment(dto.getEquipment().stream()
                     .filter(e -> e != null && e.getType() != null && !e.getType().isBlank())
-                    .map(WorkPlanDto.EquipmentEntry::toEntity)
-                    .toList());
+                    .map(WorkPlanDto.EquipmentEntry::toEntity).toList());
         }
+
+        linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
+        linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
     }
 
     // 일정 연장 등록/수정
     @Transactional
     public void extend(Long planId, WorkPlanDto.ExtReq dto) {
         WorkPlan plan = findPlan(planId);
-
         WorkPlanExtension extension = plan.getExtension();
 
         if (extension == null) {
@@ -114,26 +110,19 @@ public class WorkPlanService {
         }
 
         Integer addedDays = dto.getAddedDays();
-
         if (addedDays == null && plan.getEndDate() != null && dto.getExtendedEnd() != null) {
             addedDays = (int) ChronoUnit.DAYS.between(plan.getEndDate(), dto.getExtendedEnd());
         }
 
-        extension.update(
-                dto.getExtendedEnd(),
-                addedDays,
-                dto.getReason(),
-                LocalDate.now()
-        );
+        extension.update(dto.getExtendedEnd(), addedDays, dto.getReason(), LocalDate.now());
     }
 
-    // 주간 계획서 일괄 제출 (협력사 담당자가 한 번에 여러 일자 작업 등록)
+    // 주간 계획서 일괄 제출
     @Transactional
     public List<Long> submitWeekly(WorkPlanDto.WeeklySubmitReq dto) {
         if (dto.getItems() == null || dto.getItems().isEmpty()) {
             throw new RuntimeException("제출할 작업 항목이 없습니다.");
         }
-
         if (dto.getPartner() == null || dto.getPartner().isBlank()
                 || dto.getManager() == null || dto.getManager().isBlank()) {
             throw new RuntimeException("협력사명과 담당자명은 필수입니다.");
@@ -157,87 +146,79 @@ public class WorkPlanService {
                     .note(item.getNote())
                     .build();
 
-            // 인력 등록 (replaceWorkers 호출이 requiredCount 자동 계산)
-            List<WorkPlanWorker> workerEntities = item.getWorkers().stream()
+            plan.replaceWorkers(item.getWorkers().stream()
                     .filter(w -> w != null && w.getTrade() != null && !w.getTrade().isBlank())
-                    .map(WorkPlanDto.WorkerEntry::toEntity)
-                    .toList();
+                    .map(WorkPlanDto.WorkerEntry::toEntity).toList());
 
-            plan.replaceWorkers(workerEntities);
-
-            // 장비 등록
-            List<WorkPlanEquipment> equipmentEntities = item.getEquipment().stream()
+            plan.replaceEquipment(item.getEquipment().stream()
                     .filter(e -> e != null && e.getType() != null && !e.getType().isBlank())
-                    .map(WorkPlanDto.EquipmentEntry::toEntity)
-                    .toList();
+                    .map(WorkPlanDto.EquipmentEntry::toEntity).toList());
 
-            plan.replaceEquipment(equipmentEntities);
+            linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
+            linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
 
-            WorkPlan saved = workPlanRepository.save(plan);
-            savedIds.add(saved.getIdx());
+            savedIds.add(workPlanRepository.save(plan).getIdx());
         }
 
         return savedIds;
     }
 
-    // 작업 착수 처리 (실제 시작일 기록)
+    // 작업 착수 처리
     @Transactional
     public void start(Long planId) {
-        WorkPlan plan = findPlan(planId);
-
-        plan.markStarted(LocalDate.now());
+        findPlan(planId).markStarted(LocalDate.now());
     }
 
     // 작업 계획 삭제
     @Transactional
     public void delete(Long planId) {
-        WorkPlan plan = findPlan(planId);
-
-        workPlanRepository.delete(plan);
+        workPlanRepository.delete(findPlan(planId));
     }
+
 
     private WorkPlan findPlan(Long planId) {
         return workPlanRepository.findById(planId)
                 .orElseThrow(() -> new RuntimeException("작업 계획을 찾을 수 없습니다."));
     }
 
+    /**
+     * tradeProcessId가 있을 때만 공정 연결.
+     * null이면 기존 연결 유지 (연결 해제는 별도 API로 분리 권장).
+     */
+    private void linkTradeProcessIfPresent(WorkPlan plan, Long tradeProcessId) {
+        if (tradeProcessId == null) return;
+
+        TradeProcess tradeProcess = tradeProcessRepository.findById(tradeProcessId)
+                .orElseThrow(() -> new RuntimeException("공정을 찾을 수 없습니다. id=" + tradeProcessId));
+
+        plan.linkTradeProcess(tradeProcess);
+    }
+
+    private void linkParentWorkPlanIfPresent(WorkPlan plan, Long parentWorkPlanId) {
+        if (parentWorkPlanId == null) return;
+
+        WorkPlan parent = workPlanRepository.findById(parentWorkPlanId)
+                .orElseThrow(() -> new RuntimeException("상위 작업 계획을 찾을 수 없습니다. id=" + parentWorkPlanId));
+
+        plan.linkParentWorkPlan(parent);
+    }
+
     private void validateWeeklyItem(WorkPlanDto.WeeklyItemReq item) {
-        if (item.getDate() == null) {
-            throw new RuntimeException("작업일자는 필수입니다.");
-        }
-
-        if (item.getProcessName() == null || item.getProcessName().isBlank()) {
-            throw new RuntimeException("공정명은 필수입니다.");
-        }
-
-        if (item.getZone() == null || item.getZone().isBlank()) {
-            throw new RuntimeException("작업구역은 필수입니다.");
-        }
-
-        if (item.getWorkers() == null || item.getWorkers().isEmpty()) {
-            throw new RuntimeException("인력은 최소 1개 이상 필요합니다.");
-        }
+        if (item.getDate() == null) throw new RuntimeException("작업일자는 필수입니다.");
+        if (item.getProcessName() == null || item.getProcessName().isBlank()) throw new RuntimeException("공정명은 필수입니다.");
+        if (item.getZone() == null || item.getZone().isBlank()) throw new RuntimeException("작업구역은 필수입니다.");
+        if (item.getWorkers() == null || item.getWorkers().isEmpty()) throw new RuntimeException("인력은 최소 1개 이상 필요합니다.");
 
         boolean hasValidWorker = item.getWorkers().stream()
-                .anyMatch(w -> w != null
-                        && w.getTrade() != null && !w.getTrade().isBlank()
+                .anyMatch(w -> w != null && w.getTrade() != null && !w.getTrade().isBlank()
                         && w.getCount() != null && w.getCount() > 0);
+        if (!hasValidWorker) throw new RuntimeException("유효한 인력 항목이 없습니다.");
 
-        if (!hasValidWorker) {
-            throw new RuntimeException("유효한 인력 항목이 없습니다.");
-        }
-
-        if (item.getEquipment() == null || item.getEquipment().isEmpty()) {
-            throw new RuntimeException("장비는 최소 1개 이상 필요합니다.");
-        }
+        if (item.getEquipment() == null || item.getEquipment().isEmpty()) throw new RuntimeException("장비는 최소 1개 이상 필요합니다.");
 
         boolean hasValidEquipment = item.getEquipment().stream()
-                .anyMatch(e -> e != null
-                        && e.getType() != null && !e.getType().isBlank()
+                .anyMatch(e -> e != null && e.getType() != null && !e.getType().isBlank()
                         && e.getCount() != null && e.getCount() > 0);
-
-        if (!hasValidEquipment) {
-            throw new RuntimeException("유효한 장비 항목이 없습니다.");
-        }
+        if (!hasValidEquipment) throw new RuntimeException("유효한 장비 항목이 없습니다.");
     }
 }

--- a/src/main/java/org/example/dndn/workplan/model/WorkPlanDto.java
+++ b/src/main/java/org/example/dndn/workplan/model/WorkPlanDto.java
@@ -1,6 +1,11 @@
 package org.example.dndn.workplan.model;
 
 import lombok.*;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.entity.WorkPlanEquipment;
+import org.example.dndn.workplan.model.entity.WorkPlanExtension;
+import org.example.dndn.workplan.model.entity.WorkPlanWorker;
+import org.example.dndn.workplan.model.enums.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -12,33 +17,18 @@ public class WorkPlanDto {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     /**
-     * 인력 항목 - 직종 + 인원수.
-     * 요청/응답 공용.
+     * 인력 항목 - 직종 + 인원수. 요청/응답 공용.
      */
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class WorkerEntry {
-        private String trade;     // 직종 라벨 (예: "전공", "보통공")
-        private Integer count;    // 인원수
+        private String trade;
+        private Integer count;
 
         public WorkPlanWorker toEntity() {
             WorkerTrade tradeEnum = WorkerTrade.fromLabel(this.trade);
-
-            if (tradeEnum == null) {
-                throw new IllegalArgumentException("직종은 필수입니다.");
-            }
-
-            if (this.count == null || this.count < 1) {
-                throw new IllegalArgumentException("인원수는 1명 이상이어야 합니다.");
-            }
-
-            return WorkPlanWorker.builder()
-                    .trade(tradeEnum)
-                    .count(this.count)
-                    .build();
+            if (tradeEnum == null) throw new IllegalArgumentException("직종은 필수입니다.");
+            if (this.count == null || this.count < 1) throw new IllegalArgumentException("인원수는 1명 이상이어야 합니다.");
+            return WorkPlanWorker.builder().trade(tradeEnum).count(this.count).build();
         }
 
         public static WorkerEntry from(WorkPlanWorker entity) {
@@ -50,33 +40,18 @@ public class WorkPlanDto {
     }
 
     /**
-     * 장비 항목 - 장비 종류 + 수량.
-     * 요청/응답 공용.
+     * 장비 항목 - 장비 종류 + 수량. 요청/응답 공용.
      */
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class EquipmentEntry {
-        private String type;      // 장비 라벨 (예: "타워크레인")
-        private Integer count;    // 수량
+        private String type;
+        private Integer count;
 
         public WorkPlanEquipment toEntity() {
             EquipmentType typeEnum = EquipmentType.fromLabel(this.type);
-
-            if (typeEnum == null) {
-                throw new IllegalArgumentException("장비 종류는 필수입니다.");
-            }
-
-            if (this.count == null || this.count < 1) {
-                throw new IllegalArgumentException("수량은 1대 이상이어야 합니다.");
-            }
-
-            return WorkPlanEquipment.builder()
-                    .type(typeEnum)
-                    .count(this.count)
-                    .build();
+            if (typeEnum == null) throw new IllegalArgumentException("장비 종류는 필수입니다.");
+            if (this.count == null || this.count < 1) throw new IllegalArgumentException("수량은 1대 이상이어야 합니다.");
+            return WorkPlanEquipment.builder().type(typeEnum).count(this.count).build();
         }
 
         public static EquipmentEntry from(WorkPlanEquipment entity) {
@@ -87,25 +62,25 @@ public class WorkPlanDto {
         }
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class Req {
+        // ── 1단계 추가 ───────────────────────────────────────────────────────
+        private Long tradeProcessId;  // 상위 공정 연결 (선택 — 없으면 null)
+        // ────────────────────────────────────────────────────────────────────
+        private Long parentWorkPlanId;
         private String name;
-        private String trade;            // 공종 라벨
+        private String trade;
         private String location;
-        private String planType;         // "연간" | "월간" | "주간"
-        private String status;           // "계획" | "검토 중" | "확정" | "진행 중"
+        private String planType;
+        private String status;
         private LocalDate startDate;
         private LocalDate endDate;
         private String partner;
         private String manager;
         private String contact;
         private String note;
-        private List<WorkerEntry> workers;       // 직종별 인력
-        private List<EquipmentEntry> equipment;   // 장비별 수량
+        private List<WorkerEntry> workers;
+        private List<EquipmentEntry> equipment;
 
         public WorkPlan toEntity() {
             WorkPlan plan = WorkPlan.builder()
@@ -123,44 +98,30 @@ public class WorkPlanDto {
                     .build();
 
             if (this.workers != null) {
-                List<WorkPlanWorker> workerList = this.workers.stream()
+                plan.replaceWorkers(this.workers.stream()
                         .filter(w -> w != null && w.getTrade() != null && !w.getTrade().isBlank())
-                        .map(WorkerEntry::toEntity)
-                        .toList();
-
-                plan.replaceWorkers(workerList);
+                        .map(WorkerEntry::toEntity).toList());
             }
-
             if (this.equipment != null) {
-                List<WorkPlanEquipment> equipmentList = this.equipment.stream()
+                plan.replaceEquipment(this.equipment.stream()
                         .filter(e -> e != null && e.getType() != null && !e.getType().isBlank())
-                        .map(EquipmentEntry::toEntity)
-                        .toList();
-
-                plan.replaceEquipment(equipmentList);
+                        .map(EquipmentEntry::toEntity).toList());
             }
-
             return plan;
         }
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class ExtReq {
         private LocalDate extendedEnd;
         private Integer addedDays;
         private String reason;
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class WeeklySubmitReq {
+        private Long tradeProcessId;
+        private Long parentWorkPlanId;
         private String partner;
         private String manager;
         private String contact;
@@ -168,25 +129,24 @@ public class WorkPlanDto {
         private List<WeeklyItemReq> items;
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
+    @Getter @Setter @AllArgsConstructor @NoArgsConstructor @Builder
     public static class WeeklyItemReq {
         private LocalDate date;
-        private String processName;             // 공정명 → name 매핑
-        private String zone;                     // 작업구역 → location 매핑
-        private List<WorkerEntry> workers;       // 직종별 인력
-        private List<EquipmentEntry> equipment;  // 장비별 수량
+        private String processName;
+        private String zone;
+        private List<WorkerEntry> workers;
+        private List<EquipmentEntry> equipment;
         private String note;
     }
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
     public static class Res {
+        // ── 1단계 추가 ───────────────────────────────────────────────────────
+        private Long tradeProcessId;    // 연결된 공정 ID
+        private String tradeProcessName; // 연결된 공정명 (표시용)
+        // ────────────────────────────────────────────────────────────────────
+        private Long parentWorkPlanId;
+        private String parentWorkPlanName;
         private Long idx;
         private String name;
         private String trade;
@@ -203,39 +163,40 @@ public class WorkPlanDto {
         private String manager;
         private String contact;
         private String note;
-        private List<WorkerEntry> workers;        // 구조화 데이터
-        private String workersDisplay;             // 표시용 ("전공 4명, 보통공 2명")
-        private List<EquipmentEntry> equipment;    // 구조화 데이터
-        private String equipmentDisplay;           // 표시용 ("타워크레인 1대, 펌프카 1대")
+        private List<WorkerEntry> workers;
+        private String workersDisplay;
+        private List<EquipmentEntry> equipment;
+        private String equipmentDisplay;
         private ExtRes extension;
 
         public static Res from(WorkPlan entity) {
             String period = "";
-
             if (entity.getStartDate() != null && entity.getEndDate() != null) {
-                period = entity.getStartDate().format(DATE_FORMATTER) + " ~ "
-                        + entity.getEndDate().format(DATE_FORMATTER);
+                period = entity.getStartDate().format(DATE_FORMATTER)
+                        + " ~ " + entity.getEndDate().format(DATE_FORMATTER);
             }
 
-            List<WorkerEntry> workerDto = new ArrayList<>();
+            List<WorkerEntry> workerDto = entity.getWorkers() != null
+                    ? entity.getWorkers().stream().map(WorkerEntry::from).toList()
+                    : new ArrayList<>();
 
-            if (entity.getWorkers() != null) {
-                workerDto = entity.getWorkers().stream()
-                        .map(WorkerEntry::from)
-                        .toList();
-            }
-
-            List<EquipmentEntry> equipmentDto = new ArrayList<>();
-
-            if (entity.getEquipment() != null) {
-                equipmentDto = entity.getEquipment().stream()
-                        .map(EquipmentEntry::from)
-                        .toList();
-            }
+            List<EquipmentEntry> equipmentDto = entity.getEquipment() != null
+                    ? entity.getEquipment().stream().map(EquipmentEntry::from).toList()
+                    : new ArrayList<>();
 
             return Res.builder()
+                    // ── 1단계 추가 ──────────────────────────────────────────
+                    .tradeProcessId(entity.getTradeProcess() != null
+                            ? entity.getTradeProcess().getIdx() : null)
+                    .tradeProcessName(entity.getTradeProcess() != null
+                            ? entity.getTradeProcess().getProcessName() : null)
+                    // ────────────────────────────────────────────────────────
                     .idx(entity.getIdx())
                     .name(entity.getName())
+                    .parentWorkPlanId(entity.getParentWorkPlan() != null
+                            ? entity.getParentWorkPlan().getIdx() : null)
+                    .parentWorkPlanName(entity.getParentWorkPlan() != null
+                            ? entity.getParentWorkPlan().getName() : null)
                     .trade(entity.getTrade() == null ? null : entity.getTrade().getLabel())
                     .location(entity.getLocation())
                     .planType(entity.getPlanType() == null ? null : entity.getPlanType().getLabel())
@@ -259,11 +220,12 @@ public class WorkPlanDto {
         }
     }
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
     public static class workPlanRes {
+        // ── 1단계 추가 ───────────────────────────────────────────────────────
+        private Long tradeProcessId;
+        private String tradeProcessName;
+        // ────────────────────────────────────────────────────────────────────
         private Long idx;
         private String name;
         private String trade;
@@ -275,8 +237,8 @@ public class WorkPlanDto {
         private LocalDate endDate;
         private LocalDate effectiveEnd;
         private Integer requiredCount;
-        private String workersDisplay;    // 목록 표시용 ("전공 4명, 보통공 2명")
-        private String equipmentDisplay;  // 목록 표시용 ("타워크레인 1대, 펌프카 1대")
+        private String workersDisplay;
+        private String equipmentDisplay;
         private Integer addedDays;
         private String partner;
         private String manager;
@@ -285,19 +247,20 @@ public class WorkPlanDto {
 
         public static workPlanRes from(WorkPlan entity) {
             String period = "";
-
             if (entity.getStartDate() != null && entity.getEndDate() != null) {
-                period = entity.getStartDate().format(DATE_FORMATTER) + " ~ "
-                        + entity.getEndDate().format(DATE_FORMATTER);
+                period = entity.getStartDate().format(DATE_FORMATTER)
+                        + " ~ " + entity.getEndDate().format(DATE_FORMATTER);
             }
-
-            Integer addedDays = null;
-
-            if (entity.getExtension() != null) {
-                addedDays = entity.getExtension().getAddedDays();
-            }
+            Integer addedDays = entity.getExtension() != null
+                    ? entity.getExtension().getAddedDays() : null;
 
             return workPlanRes.builder()
+                    // ── 1단계 추가 ──────────────────────────────────────────
+                    .tradeProcessId(entity.getTradeProcess() != null
+                            ? entity.getTradeProcess().getIdx() : null)
+                    .tradeProcessName(entity.getTradeProcess() != null
+                            ? entity.getTradeProcess().getProcessName() : null)
+                    // ────────────────────────────────────────────────────────
                     .idx(entity.getIdx())
                     .name(entity.getName())
                     .trade(entity.getTrade() == null ? null : entity.getTrade().getLabel())
@@ -320,10 +283,7 @@ public class WorkPlanDto {
         }
     }
 
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
     public static class ExtRes {
         private LocalDate extendedEnd;
         private Integer addedDays;
@@ -331,19 +291,13 @@ public class WorkPlanDto {
         private String decidedAt;
 
         public static ExtRes from(WorkPlanExtension entity) {
-            if (entity == null) {
-                return null;
-            }
-
-            String decidedAt = entity.getDecidedAt() != null
-                    ? entity.getDecidedAt().format(DATE_FORMATTER)
-                    : "";
-
+            if (entity == null) return null;
             return ExtRes.builder()
                     .extendedEnd(entity.getExtendedEnd())
                     .addedDays(entity.getAddedDays())
                     .reason(entity.getReason())
-                    .decidedAt(decidedAt)
+                    .decidedAt(entity.getDecidedAt() != null
+                            ? entity.getDecidedAt().format(DATE_FORMATTER) : "")
                     .build();
         }
     }

--- a/src/main/java/org/example/dndn/workplan/model/entity/WorkPlan.java
+++ b/src/main/java/org/example/dndn/workplan/model/entity/WorkPlan.java
@@ -1,8 +1,12 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.workplan.model.enums.PlanStatus;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.example.dndn.workplan.model.enums.WorkTrade;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -16,37 +20,47 @@ import java.util.stream.Collectors;
 @Entity
 @Table(name = "work_plan")
 public class WorkPlan extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    private String name;            // 작업명 (공정명)
-    private String location;        // 작업 위치/구역
+    // 상위 공정(마스터 공정표)과 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trade_process_id")
+    private TradeProcess tradeProcess;
+
+    // 상위 작업 계획과 연결
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_work_plan_id")
+    private WorkPlan parentWorkPlan;
+
+    @OneToMany(mappedBy = "parentWorkPlan", fetch = FetchType.LAZY)
+    @Builder.Default
+    private List<WorkPlan> childWorkPlans = new ArrayList<>();
+
+    private String name;        // 작업명 (공정명)
+    private String location;    // 작업 위치/구역
 
     @Enumerated(EnumType.STRING)
-    private WorkTrade trade;        // 공종
+    private WorkTrade trade;    // 공종
 
     @Enumerated(EnumType.STRING)
-    private PlanType planType;      // 연간/월간/주간
+    private PlanType planType;  // 연간/월간/주간
 
     @Enumerated(EnumType.STRING)
-    private PlanStatus status;      // 계획/검토 중/확정/진행 중
+    private PlanStatus status;  // 진행 예정/진행 중
 
-    private LocalDate startDate;    // 계획 시작일
-    private LocalDate endDate;      // 계획 종료일
-    private LocalDate actualStart;  // 실제 시작일
+    private LocalDate startDate;   // 계획 시작일
+    private LocalDate endDate;     // 계획 종료일
+    private LocalDate actualStart; // 실제 시작일
 
-    /**
-     * 필요 인원 - workers 합산값으로 자동 계산되는 derived 컬럼.
-     * 외부에서 직접 set하지 않음. replaceWorkers() 호출 시 자동 동기화.
-     * 컬럼 자체는 유지(검색/정렬/통계 편의).
-     */
     private Integer requiredCount;
 
-    private String partner;         // 협력사명 (주간 계획서)
-    private String manager;         // 담당자명 (주간 계획서)
-    private String contact;         // 담당자 연락처
-    private String note;            // 비고
+    private String partner; // 협력사명
+    private String manager; // 담당자명
+    private String contact; // 담당자 연락처
+    private String note;    // 비고
 
     @OneToMany(mappedBy = "workPlan", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -60,19 +74,26 @@ public class WorkPlan extends BaseEntity {
     private WorkPlanExtension extension;
 
     /**
-     * 화면에 보일 최종 종료일 - 연장이 있으면 연장 종료일, 없으면 원래 종료일
+     * 화면에 보일 최종 종료일 — 연장이 있으면 연장 종료일, 없으면 원래 종료일
      */
     public LocalDate effectiveEndDate() {
         if (extension != null && extension.getExtendedEnd() != null) {
             return extension.getExtendedEnd();
         }
-
         return endDate;
+    }
+    public void linkParentWorkPlan(WorkPlan parentWorkPlan) {
+        this.parentWorkPlan = parentWorkPlan;
+    }
+    /**
+     * 상위 공정 연결 (공정표 업로드 후 매핑 시 사용)
+     */
+    public void linkTradeProcess(TradeProcess tradeProcess) {
+        this.tradeProcess = tradeProcess;
     }
 
     /**
      * 작업 계획 기본 정보 수정
-     * - requiredCount는 받지 않음. workers로부터 자동 계산.
      */
     public void updateInfo(String name, WorkTrade trade, String location,
                            LocalDate startDate, LocalDate endDate,
@@ -95,14 +116,12 @@ public class WorkPlan extends BaseEntity {
      */
     public void replaceWorkers(List<WorkPlanWorker> newWorkers) {
         this.workers.clear();
-
         if (newWorkers != null) {
             for (WorkPlanWorker worker : newWorkers) {
                 worker.bindWorkPlan(this);
                 this.workers.add(worker);
             }
         }
-
         recalculateRequiredCount();
     }
 
@@ -111,7 +130,6 @@ public class WorkPlan extends BaseEntity {
      */
     public void replaceEquipment(List<WorkPlanEquipment> newEquipment) {
         this.equipment.clear();
-
         if (newEquipment != null) {
             for (WorkPlanEquipment eq : newEquipment) {
                 eq.bindWorkPlan(this);
@@ -135,23 +153,18 @@ public class WorkPlan extends BaseEntity {
         if (actualStart == null) {
             throw new IllegalArgumentException("실제 시작일은 필수입니다.");
         }
-
         if (this.status == PlanStatus.IN_PROGRESS) {
             throw new IllegalStateException("이미 진행 중인 작업입니다.");
         }
-
         this.actualStart = actualStart;
         this.status = PlanStatus.IN_PROGRESS;
     }
 
     /**
-     * "전공 4명, 보통공 2명" 형태의 표시용 문자열 (응답 편의용)
+     * "전공 4명, 보통공 2명" 형태의 표시용 문자열
      */
     public String workersDisplay() {
-        if (workers == null || workers.isEmpty()) {
-            return "";
-        }
-
+        if (workers == null || workers.isEmpty()) return "";
         return workers.stream()
                 .map(WorkPlanWorker::toDisplay)
                 .filter(s -> !s.isBlank())
@@ -159,28 +172,21 @@ public class WorkPlan extends BaseEntity {
     }
 
     /**
-     * "타워크레인 1대, 펌프카 1대" 형태의 표시용 문자열 (응답 편의용)
+     * "타워크레인 1대, 펌프카 1대" 형태의 표시용 문자열
      */
     public String equipmentDisplay() {
-        if (equipment == null || equipment.isEmpty()) {
-            return "";
-        }
-
+        if (equipment == null || equipment.isEmpty()) return "";
         return equipment.stream()
                 .map(WorkPlanEquipment::toDisplay)
                 .filter(s -> !s.isBlank())
                 .collect(Collectors.joining(", "));
     }
 
-    /**
-     * workers 합산으로 requiredCount 재계산
-     */
     private void recalculateRequiredCount() {
         if (workers == null || workers.isEmpty()) {
             this.requiredCount = 0;
             return;
         }
-
         this.requiredCount = workers.stream()
                 .map(WorkPlanWorker::getCount)
                 .filter(c -> c != null)

--- a/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanEquipment.java
+++ b/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanEquipment.java
@@ -1,8 +1,9 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.workplan.model.enums.EquipmentType;
 
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanExtension.java
+++ b/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanExtension.java
@@ -1,4 +1,4 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,16 +26,13 @@ public class WorkPlanExtension extends BaseEntity {
     private String reason;           // 연장 사유 (공정 분석 결과)
     private LocalDate decidedAt;     // 반영일
 
-    /**
-     * 양방향 연관관계 - WorkPlan에서 호출
-     */
+
     public void bindWorkPlan(WorkPlan workPlan) {
         this.workPlan = workPlan;
     }
 
-    /**
-     * 연장 정보 수정
-     */
+
+     // 연장 정보 수정
     public void update(LocalDate extendedEnd, Integer addedDays, String reason, LocalDate decidedAt) {
         this.extendedEnd = extendedEnd;
         this.addedDays = addedDays;

--- a/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanWorker.java
+++ b/src/main/java/org/example/dndn/workplan/model/entity/WorkPlanWorker.java
@@ -1,8 +1,9 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.workplan.model.enums.WorkerTrade;
 
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/org/example/dndn/workplan/model/enums/EquipmentType.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/EquipmentType.java
@@ -1,4 +1,4 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/example/dndn/workplan/model/enums/PlanStatus.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/PlanStatus.java
@@ -1,4 +1,4 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/example/dndn/workplan/model/enums/PlanType.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/PlanType.java
@@ -1,4 +1,4 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/example/dndn/workplan/model/enums/WorkTrade.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/WorkTrade.java
@@ -1,17 +1,24 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 @Getter
 @AllArgsConstructor
 public enum WorkTrade {
+    EARTHWORK("토공"),
     FORM("형틀"),
     ELECTRIC("전기"),
     WATERPROOF("방수"),
     FRAME("골조"),
     FACILITY("설비"),
-    REBAR("철근");
+    REBAR("철근"),
+    MASONRY("조적"),
+    PLASTER("미장"),
+    PAINT("도장"),
+    TILE("타일"),
+    LANDSCAPE("조경"),
+    PAVEMENT("포장"),
+    ETC("기타");
 
     private final String label;
 

--- a/src/main/java/org/example/dndn/workplan/model/enums/WorkerTrade.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/WorkerTrade.java
@@ -1,4 +1,4 @@
-package org.example.dndn.workplan.model;
+package org.example.dndn.workplan.model.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## :hammer_and_wrench: 작업 내용
- 연간, 월간, 주간 계획서 작성 기능 추가
- 계획서 업로드 기능 추가
- 공정 계획 데이터를 기준으로 작업 계획을 등록하고 조회할 수 있도록 구현

## :clipboard: 상세 내용
- 계획 유형별 작성 화면 및 등록 로직 구성
- 연간/월간/주간 계획서 데이터 입력 기능 추가
- 계획서 파일 업로드 처리 기능 추가
- 등록된 계획서 목록 조회 기능 추가
- 공정 계획과 연결되는 작업 계획 데이터 구조 반영
- 계획 유형에 따라 화면과 요청 데이터를 분리하여 처리

## :white_check_mark: 테스트 내용
- 연간 계획서 작성 및 등록 확인
- 월간 계획서 작성 및 등록 확인
- 주간 계획서 작성 및 등록 확인
- 계획서 업로드 요청 동작 확인
- 등록된 계획서 목록 조회 확인

## :pushpin: 참고 사항
- 주간 계획은 작업지시서 생성 및 공사일보 작성 흐름과 연결
- 연간/월간 계획은 간트차트의 세부 실행 일정 데이터로 활용
closed #203
closed #204
closed #205 