### PR TITLE
[Feat] 작업지시서 작성 및 장비 배정 기능 추가

### DIFF
--- a/src/main/java/org/example/dndn/workorder/WorkOrderController.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderController.java
@@ -1,0 +1,57 @@
+package org.example.dndn.workorder;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.common.model.BaseResponse;
+import org.example.dndn.workorder.model.WorkOrderDto;
+import org.example.dndn.workorder.model.WorkOrderEquipmentDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/work-order")
+@RequiredArgsConstructor
+public class WorkOrderController {
+
+    private final WorkOrderService workOrderService;
+
+    // [WORKORDER_001] 1단계 : 작업 지시서 기본 작성 기능 API
+    // feat : 작업 지시서 생성 API
+    @PostMapping
+    public ResponseEntity<?> createWorkOrder(@RequestBody WorkOrderDto.Req req) {
+        workOrderService.createWorkOrder(req);
+        return ResponseEntity.ok(BaseResponse.success("작업 지시서가 성공적으로 생성되었습니다."));
+    }
+
+    // [WORKORDER_003] 3단계 : 작업 지시서 목록 조회 기능 API
+    // feat : 작업 지시서 목록 조회 API
+    @GetMapping
+    public ResponseEntity<?> getWorkOrderList() {
+        List<WorkOrderDto.Res> list = workOrderService.getWorkOrderList();
+        return ResponseEntity.ok(BaseResponse.success(list));
+    }
+
+    // [WORKORDER_004] 4단계 : 작업 지시서 단건 수정 기능 API
+    // feat : 작업 지시서 단건 수정 API (장비 갱신 포함)
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateWorkOrder(@PathVariable Long id, @RequestBody WorkOrderDto.Req req) {
+        workOrderService.updateWorkOrder(id, req);
+        return ResponseEntity.ok(BaseResponse.success("작업 지시서가 성공적으로 수정되었습니다."));
+    }
+
+    // [WORKORDER_007] 7단계 : 작업 지시서 승인 및 주간 계획 반영 기능 API
+    // feat : 작업 지시서 승인 API
+    @PutMapping("/{id}/approve")
+    public ResponseEntity<?> approveWorkOrder(@PathVariable Long id) {
+        workOrderService.approveWorkOrder(id);
+        return ResponseEntity.ok(BaseResponse.success("작업지시서가 승인되어 주간 계획에 반영되었습니다."));
+    }
+
+    // [WORKORDER_006] 6단계 : 주간계획 연동 초안 장비 불러오기 기능 API
+    // feat : 초안 작성을 위한 예정 장비 목록 조회 API
+    @GetMapping("/draft-equipments/{planIdx}")
+    public ResponseEntity<?> getDraftEquipments(@PathVariable Long planIdx) {
+        List<WorkOrderEquipmentDto> list = workOrderService.getDraftEquipments(planIdx);
+        return ResponseEntity.ok(BaseResponse.success(list));
+    }
+}

--- a/src/main/java/org/example/dndn/workorder/WorkOrderEquipmentRepository.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderEquipmentRepository.java
@@ -1,0 +1,17 @@
+package org.example.dndn.workorder;
+
+import org.example.dndn.workorder.model.WorkOrderEquipment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+// [WORKORDER_002] 2단계 : 작업 지시서 장비 Repository
+public interface WorkOrderEquipmentRepository extends JpaRepository<WorkOrderEquipment, Long> {
+
+    // [WORKORDER_005] 5단계 : 기존 장비 일괄 삭제 쿼리 추가
+    // feat : 특정 작업 지시서에 연결된 장비 일괄 삭제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM WorkOrderEquipment e WHERE e.workOrder.idx = :orderIdx")
+    void deleteAllByWorkOrderIdx(@Param("orderIdx") Long orderIdx);
+}

--- a/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
@@ -1,0 +1,17 @@
+package org.example.dndn.workorder;
+
+import org.example.dndn.workorder.model.WorkOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+// [WORKORDER_003] 3단계 : 작업 지시서 Repository
+public interface WorkOrderRepository extends JpaRepository<WorkOrder, Long> {
+
+    // [WORKORDER_006] 6단계 : 주간계획 연동 초안 장비 불러오기 기능 쿼리
+    // feat : WorkPlan 도메인 수정 없이 DB에서 장비 정보 조회
+    @Query(value = "SELECT e.type, e.count FROM work_plan_equipment e WHERE e.work_plan_idx = :planIdx", nativeQuery = true)
+    List<Object[]> findEquipmentsByPlanIdx(@Param("planIdx") Long planIdx);
+}

--- a/src/main/java/org/example/dndn/workorder/WorkOrderService.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderService.java
@@ -1,0 +1,198 @@
+package org.example.dndn.workorder;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.workorder.model.WorkOrder;
+import org.example.dndn.workorder.model.WorkOrderDto;
+import org.example.dndn.workorder.model.WorkOrderEquipment;
+import org.example.dndn.workorder.model.WorkOrderEquipmentDto;
+import org.example.dndn.workplan.WorkPlanRepository;
+import org.example.dndn.workplan.model.WorkPlanDto;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.enums.PlanStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+// feat : 작업 지시서 비즈니스 로직 처리 클래스
+@Service
+@RequiredArgsConstructor
+public class WorkOrderService {
+
+    private final WorkOrderRepository workOrderRepository;
+    private final WorkOrderEquipmentRepository workOrderEquipmentRepository;
+    private final WorkPlanRepository workPlanRepository;
+
+    // [WORKORDER_001] 1단계 : 작업 지시서 기본 작성 기능
+    // feat : 작업 지시서 신규 생성
+    @Transactional
+    public void createWorkOrder(WorkOrderDto.Req req) {
+        WorkOrder workOrder = WorkOrder.builder()
+                .siteIdx(req.getSiteIdx())
+                .partnerCompanyIdx(req.getPartnerCompanyIdx())
+                .workPlanId(req.getWorkPlanId())
+                .tradeType(req.getTradeType())
+                .title(req.getTitle())
+                .instructionContent(req.getInstructionContent())
+                .dueDate(req.getDueDate())
+                .statusCode(req.getStatusCode())
+                .workerCount(req.getWorkerCount())
+                .build();
+
+        // feat : 신규 지시서 저장 및 ID 발급
+        workOrder = workOrderRepository.saveAndFlush(workOrder);
+
+        // feat : 기존 장비 데이터 초기화
+        workOrderEquipmentRepository.deleteAllByWorkOrderIdx(workOrder.getIdx());
+
+        // [WORKORDER_002] 2단계 : 장비 매핑 로직 추가
+        // feat : 신규 장비 데이터 연관관계 매핑 및 추가
+        if (req.getEquipments() != null) {
+            for (WorkOrderEquipmentDto eqDto : req.getEquipments()) {
+                WorkOrderEquipment equipment = WorkOrderEquipment.builder()
+                        .gateIdx(eqDto.getGateIdx())
+                        .equipmentName(eqDto.getEquipmentName())
+                        .equipmentCount(eqDto.getEquipmentCount())
+                        .build();
+                workOrder.addEquipment(equipment);
+            }
+        }
+
+        // feat : 최종 저장
+        workOrderRepository.save(workOrder);
+    }
+
+    // [WORKORDER_003] 3단계 : 지시서 목록 조회 기능
+    // feat : 작업 지시서 목록 전체 조회
+    @Transactional(readOnly = true)
+    public List<WorkOrderDto.Res> getWorkOrderList() {
+        return workOrderRepository.findAll().stream().map(order -> {
+            List<WorkOrderEquipmentDto> eqDtos = order.getEquipments().stream()
+                    .map(eq -> WorkOrderEquipmentDto.builder()
+                            .idx(eq.getIdx())
+                            .gateIdx(eq.getGateIdx())
+                            .equipmentName(eq.getEquipmentName())
+                            .equipmentCount(eq.getEquipmentCount())
+                            .build())
+                    .collect(Collectors.toList());
+
+            return WorkOrderDto.Res.builder()
+                    .idx(order.getIdx())
+                    .siteIdx(order.getSiteIdx())
+                    .partnerCompanyIdx(order.getPartnerCompanyIdx())
+                    .workPlanId(order.getWorkPlanId())
+                    .tradeType(order.getTradeType())
+                    .title(order.getTitle())
+                    .instructionContent(order.getInstructionContent())
+                    .dueDate(order.getDueDate())
+                    .statusCode(order.getStatusCode())
+                    .workerCount(order.getWorkerCount())
+                    .equipments(eqDtos)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    // [WORKORDER_004] 4단계 : 작업 지시서 단건 수정 기능
+    // feat : 작업 지시서 내용 및 연관 장비 수정
+    @Transactional
+    public void updateWorkOrder(Long id, WorkOrderDto.Req req) {
+        WorkOrder workOrder = workOrderRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("작업 지시서를 찾을 수 없습니다."));
+
+        // feat : 기본 정보 업데이트
+        workOrder.setSiteIdx(req.getSiteIdx());
+        workOrder.setPartnerCompanyIdx(req.getPartnerCompanyIdx());
+        workOrder.setWorkPlanId(req.getWorkPlanId());
+        workOrder.setTradeType(req.getTradeType());
+        workOrder.setTitle(req.getTitle());
+        workOrder.setInstructionContent(req.getInstructionContent());
+        workOrder.setDueDate(req.getDueDate());
+        workOrder.setStatusCode(req.getStatusCode());
+        workOrder.setWorkerCount(req.getWorkerCount());
+
+        // [WORKORDER_005] 5단계 : 장비 초기화 로직 추가 (수정 기능 고도화)
+        // feat : JPA의 정상적인 삭제 사이클을 이용해 기존 장비 목록 초기화
+        workOrder.clearEquipments();
+        workOrderRepository.flush(); // 기존 장비 DELETE 쿼리를 DB에 먼저 전송하여 충돌 방지
+
+        // [WORKORDER_002] 2단계 : 장비 매핑 로직 추가
+        // feat : 클라이언트로부터 전달받은 신규 장비 목록 연관관계 매핑 및 추가
+        if (req.getEquipments() != null) {
+            for (WorkOrderEquipmentDto eqDto : req.getEquipments()) {
+                WorkOrderEquipment equipment = WorkOrderEquipment.builder()
+                        .gateIdx(eqDto.getGateIdx())
+                        .equipmentName(eqDto.getEquipmentName())
+                        .equipmentCount(eqDto.getEquipmentCount())
+                        .build();
+                workOrder.addEquipment(equipment);
+            }
+        }
+
+        workOrderRepository.save(workOrder);
+    }
+
+    // [WORKORDER_006] 6단계 : 주간계획 연동 초안 장비 불러오기 기능
+    // feat : 초안 생성 시 장비만 별도로 조회하여 반환
+    @Transactional(readOnly = true)
+    public List<WorkOrderEquipmentDto> getDraftEquipments(Long planIdx) {
+        List<Object[]> results = workOrderRepository.findEquipmentsByPlanIdx(planIdx);
+
+        return results.stream().map(row -> {
+            String eqName = row[0] != null ? row[0].toString() : "EXCAVATOR";
+            Integer eqCount = row[1] != null ? Integer.parseInt(row[1].toString()) : 1;
+
+            return WorkOrderEquipmentDto.builder()
+                    .gateIdx(1)
+                    .equipmentName(eqName)
+                    .equipmentCount(eqCount)
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    // [WORKORDER_007] 7단계 : 작업 지시서 승인 및 주간 계획 반영 기능
+    // feat : 작업 지시서 승인 시 연결된 주간 계획에 내용과 장비 반영
+    @Transactional
+    public void approveWorkOrder(Long id) {
+        WorkOrder workOrder = workOrderRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("작업 지시서를 찾을 수 없습니다."));
+
+        if (workOrder.getWorkPlanId() == null) {
+            throw new RuntimeException("연결된 주간 작업 계획이 없습니다.");
+        }
+
+        WorkPlan weeklyPlan = workPlanRepository.findById(workOrder.getWorkPlanId())
+                .orElseThrow(() -> new RuntimeException("주간 작업 계획을 찾을 수 없습니다."));
+
+        // feat : 승인된 작업지시서 내용을 주간 작업 계획에 반영
+        weeklyPlan.updateInfo(
+                workOrder.getInstructionContent(),   // 주간 계획의 작업 내용
+                weeklyPlan.getTrade(),               // 기존 공종 유지
+                weeklyPlan.getLocation(),            // 기존 작업 위치 유지
+                workOrder.getDueDate(),              // 작업일
+                workOrder.getDueDate(),              // 작업일
+                PlanStatus.PLANNED,
+                weeklyPlan.getPartner(),
+                weeklyPlan.getManager(),
+                weeklyPlan.getContact(),
+                "작업지시서 승인 반영"
+        );
+
+        // feat : 작업지시서 장비를 주간 계획 장비로 반영
+        if (workOrder.getEquipments() != null && !workOrder.getEquipments().isEmpty()) {
+            weeklyPlan.replaceEquipment(
+                    workOrder.getEquipments().stream()
+                            .filter(eq -> eq.getEquipmentName() != null && !eq.getEquipmentName().isBlank())
+                            .map(eq -> WorkPlanDto.EquipmentEntry.builder()
+                                    .type(eq.getEquipmentName())
+                                    .count(eq.getEquipmentCount())
+                                    .build()
+                                    .toEntity())
+                            .toList()
+            );
+        }
+
+        // feat : 작업 지시서 승인 상태 변경
+        workOrder.setStatusCode("APPROVED");
+    }
+}

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrder.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrder.java
@@ -1,0 +1,69 @@
+package org.example.dndn.workorder.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.common.model.BaseEntity;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+// [WORKORDER_001] 1단계 : 작업 지시서 기본 엔티티 설계
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkOrder extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    private Long siteIdx;
+    private Long partnerCompanyIdx;
+
+    // [WORKORDER_007] 7단계 : 작업 지시서 승인 시 주간 계획 반영을 위한 연결 ID 추가
+    // feat : 작업 지시서와 연결된 주간 작업 계획 ID
+    @Column(name = "work_plan_id")
+    private Long workPlanId;
+
+    private String tradeType;
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String instructionContent;
+
+    private LocalDate dueDate;
+    private String statusCode;
+
+    // feat : 투입 인원 수
+    @Column(name = "worker_count")
+    private Integer workerCount;
+
+    // feat : 논리적 삭제 여부 (Soft Delete)
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    // [WORKORDER_002] 2단계 : 장비 매핑 로직 추가
+    // feat : 연관된 장비 목록 (Cascade 설정)
+    @OneToMany(mappedBy = "workOrder", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<WorkOrderEquipment> equipments = new ArrayList<>();
+
+    // [WORKORDER_002] 2단계 : 장비 매핑 로직 추가
+    // feat : 장비 추가 편의 메서드
+    public void addEquipment(WorkOrderEquipment equipment) {
+        equipments.add(equipment);
+        equipment.setWorkOrder(this);
+    }
+
+    // [WORKORDER_005] 5단계 : 장비 초기화 로직 추가 (수정 기능 고도화)
+    // feat : 장비 초기화 편의 메서드
+    public void clearEquipments() {
+        for (WorkOrderEquipment eq : this.equipments) {
+            eq.setWorkOrder(null);
+        }
+        this.equipments.clear();
+    }
+}

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrderDto.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrderDto.java
@@ -1,0 +1,41 @@
+package org.example.dndn.workorder.model;
+
+import lombok.*;
+import java.time.LocalDate;
+import java.util.List;
+
+public class WorkOrderDto {
+
+    // [WORKORDER_001] 1단계 : 지시서 작성 요청 DTO
+    // feat : 작업 지시서 생성/수정 요청 (Request) DTO
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Req {
+        private Long siteIdx;
+        private Long partnerCompanyIdx;
+        private Long workPlanId;
+        private String tradeType;
+        private String title;
+        private String instructionContent;
+        private LocalDate dueDate;
+        private String statusCode;
+        private Integer workerCount;
+        private List<WorkOrderEquipmentDto> equipments; // 2단계에서 활용됨
+    }
+
+    // [WORKORDER_003] 3단계 : 지시서 목록 조회 응답 DTO
+    // feat : 작업 지시서 조회 응답 (Response) DTO
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Res {
+        private Long idx;
+        private Long siteIdx;
+        private Long partnerCompanyIdx;
+        private Long workPlanId;
+        private String tradeType;
+        private String title;
+        private String instructionContent;
+        private LocalDate dueDate;
+        private String statusCode;
+        private Integer workerCount;
+        private List<WorkOrderEquipmentDto> equipments;
+    }
+}

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrderEquipment.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrderEquipment.java
@@ -1,0 +1,32 @@
+package org.example.dndn.workorder.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.common.model.BaseEntity;
+
+// [WORKORDER_002] 2단계 : 작업 지시서 장비 엔티티 추가
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkOrderEquipment extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    // feat : 작업 지시서 연관관계 매핑 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "work_order_idx")
+    private WorkOrder workOrder;
+
+    private Integer gateIdx;
+    private String equipmentName;
+    private Integer equipmentCount;
+
+    // feat : 논리적 삭제 여부 (Soft Delete)
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+}

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrderEquipmentDto.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrderEquipmentDto.java
@@ -1,0 +1,16 @@
+package org.example.dndn.workorder.model;
+
+import lombok.*;
+
+// feat : 작업 지시서 장비 데이터 전송용 DTO
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WorkOrderEquipmentDto {
+    private Long idx;
+    private Integer gateIdx;
+    private String equipmentName;
+    private Integer equipmentCount;
+}


### PR DESCRIPTION
## :hammer_and_wrench: 작업 내용
- 작업지시서 작성 기능 추가
- 작업지시서 목록 조회 및 상세 조회 기능 추가
- 작업지시서 수정 기능 추가
- 작업지시서 장비 배정 기능 추가
- 주간 계획 기반 작업지시서 생성 흐름 구현

## :clipboard: 상세 내용
- 작업지시서 기본 정보 등록 로직 구현
- 협력사, 공종, 작업일, 작업 내용 등 마스터 정보 처리
- 작업지시서 목록 조회 기능 추가
- 작업지시서 상세 조회 기능 추가
- 작업지시서 단건 수정 기능 추가
- 작업지시서에 필요한 장비 배정 및 갱신 기능 추가
- 주간 계획 데이터를 불러와 작업지시서 초안 작성에 활용
- 승인된 작업지시서를 주간 계획에 반영할 수 있는 구조 구성

## :white_check_mark: 테스트 내용
- 작업지시서 등록 확인
- 작업지시서 목록 조회 확인
- 작업지시서 상세 조회 확인
- 작업지시서 수정 확인
- 장비 배정 및 갱신 요청 확인
- 주간 계획 기반 작업지시서 데이터 불러오기 확인

## :pushpin: 참고 사항
- 작업지시서는 주간 계획과 연결되어 명일 작업 예정 및 장비 배정 흐름에 활용
- 공사일보 작성 시 실제 작업 결과와 비교할 기준 데이터로 사용

closed #154 
closed #155 
closed #156 
closed #157 
closed #158 
closed #159 