### PR TITLE
[Feat] 공사일보 작성 기능 추가

### DIFF
--- a/src/main/java/org/example/dndn/report/DailyReportController.java
+++ b/src/main/java/org/example/dndn/report/DailyReportController.java
@@ -1,0 +1,33 @@
+package org.example.dndn.report;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.common.model.BaseResponse;
+import org.example.dndn.report.model.ReportDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/report")
+@RequiredArgsConstructor
+public class DailyReportController {
+
+    private final DailyReportService dailyReportService;
+
+    // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
+    // feat : 공사일보 제출 및 저장 API
+    @PostMapping("/")
+    public ResponseEntity<BaseResponse<Long>> submitReport(@Valid @RequestBody ReportDto.Req dto) {
+        Long reportId = dailyReportService.submitReport(dto);
+        return ResponseEntity.ok(BaseResponse.success(reportId));
+    }
+
+    // [REPORT_002] 2단계 : 특정 일자 공사일보 목록 조회 기능
+    // feat : 특정 날짜의 공사일보 데이터를 반환하는 GET API 추가
+    @GetMapping("/")
+    public ResponseEntity<BaseResponse<List<ReportDto.Res>>> getReports(@RequestParam("date") LocalDate date) {
+        return ResponseEntity.ok(BaseResponse.success(dailyReportService.getReportsByDate(date)));
+    }
+}

--- a/src/main/java/org/example/dndn/report/DailyReportRepository.java
+++ b/src/main/java/org/example/dndn/report/DailyReportRepository.java
@@ -1,0 +1,18 @@
+package org.example.dndn.report;
+
+import org.example.dndn.report.model.DailyReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyReportRepository extends JpaRepository<DailyReport, Long> {
+
+    // [REPORT_002] 2단계 : 특정 일자 공사일보 목록 조회 기능
+    // feat : 특정 날짜의 공사일보 전체 목록 조회 쿼리 추가
+    List<DailyReport> findByReportDate(LocalDate reportDate);
+
+    // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
+    // feat : 중복 방지를 위한 특정 주간계획의 특정 날짜 공사일보 조회 쿼리 추가
+    Optional<DailyReport> findByWorkPlan_IdxAndReportDate(Long workPlanId, LocalDate reportDate);
+}

--- a/src/main/java/org/example/dndn/report/DailyReportService.java
+++ b/src/main/java/org/example/dndn/report/DailyReportService.java
@@ -1,0 +1,163 @@
+package org.example.dndn.report;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.report.model.DailyReport;
+import org.example.dndn.report.model.ReportDto;
+import org.example.dndn.workplan.WorkPlanRepository;
+import org.example.dndn.workplan.model.*;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.entity.WorkPlanEquipment;
+import org.example.dndn.workplan.model.entity.WorkPlanExtension;
+import org.example.dndn.workplan.model.entity.WorkPlanWorker;
+import org.example.dndn.workplan.model.enums.EquipmentType;
+import org.example.dndn.workplan.model.enums.PlanStatus;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.example.dndn.workplan.model.enums.WorkerTrade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+// feat : 공사일보 비즈니스 로직을 처리하는 서비스 클래스
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyReportService {
+
+    private final DailyReportRepository dailyReportRepository;
+    private final WorkPlanRepository workPlanRepository;
+
+    // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
+    // feat : 공사일보 제출 및 명일 작업계획(WorkPlan) 달력 자동 연동 로직
+    public Long submitReport(ReportDto.Req dto) {
+
+        // feat : 1. 공사일보 DB 조회 및 저장 로직
+        WorkPlan workPlan = workPlanRepository.findById(dto.getWorkPlanId())
+                .orElseThrow(() -> new RuntimeException("WorkPlan not found"));
+
+        DailyReport dailyReport = dailyReportRepository.findByWorkPlan_IdxAndReportDate(workPlan.getIdx(), dto.getReportDate())
+                .orElse(DailyReport.builder()
+                        .workPlan(workPlan)
+                        .reportDate(dto.getReportDate())
+                        .build());
+
+        // feat : 금일 진척률을 포함하여 공사일보 정보 업데이트
+        dailyReport.updateReport(dto.getActualProgress(), dto.getTodayProgress(), dto.getActualWorkerCount(), dto.getIssue(), dto.getTodayWork(), dto.getTomorrowPlan());
+        DailyReport savedReport = dailyReportRepository.save(dailyReport);
+
+        // [REPORT_004] 4단계 : 진척률 미달 시 공정 기간 자동 연장 기능
+        // feat : 2. 진척률 100% 미달 시 원본 공정 기간 자동 연장 로직
+        if (dto.getActualProgress() < 100.0) {
+            WorkPlanExtension extension = workPlan.getExtension();
+            if (extension == null) {
+                extension = WorkPlanExtension.builder().build();
+                workPlan.attachExtension(extension);
+            }
+            int addedDays = extension.getAddedDays() == null ? 1 : extension.getAddedDays() + 1;
+            if (workPlan.getEndDate() != null) {
+                LocalDate extendedEnd = workPlan.getEndDate().plusDays(addedDays);
+                extension.update(extendedEnd, addedDays, dto.getIssue(), LocalDate.now());
+            }
+        }
+
+        // [REPORT_005] 5단계 : 명일 작업 스케줄(WorkPlan) 기본 정보 자동 생성 기능
+        // feat : 3. 명일 스케줄 달력 반영을 위한 1일짜리 예정 데이터 자동 생성
+        LocalDate tomorrow = dto.getReportDate().plusDays(1);
+        String tomorrowName = workPlan.getName() + " (명일 예정)";
+
+        List<WorkPlan> existingPlans = workPlanRepository.findAllByPlanType(PlanType.WEEKLY);
+        WorkPlan tomorrowPlan = existingPlans.stream()
+                .filter(p -> p.getStartDate() != null && p.getStartDate().equals(tomorrow))
+                .filter(p -> p.getTrade() == workPlan.getTrade())
+                .filter(p -> p.getName() != null && p.getName().equals(tomorrowName))
+                .findFirst()
+                .orElse(WorkPlan.builder()
+                        .name(tomorrowName)
+                        .trade(workPlan.getTrade())
+                        .location(workPlan.getLocation())
+                        .planType(PlanType.WEEKLY)
+                        .status(PlanStatus.PLANNED)
+                        .startDate(tomorrow)
+                        .endDate(tomorrow)
+                        .partner(workPlan.getPartner())
+                        .manager(workPlan.getManager())
+                        .contact(workPlan.getContact())
+                        .build());
+
+        // feat : 달력에 표시될 명일 작업 내용 텍스트 업데이트
+        tomorrowPlan.updateInfo(
+                tomorrowName, workPlan.getTrade(), workPlan.getLocation(),
+                tomorrow, tomorrow, PlanStatus.PLANNED,
+                workPlan.getPartner(), workPlan.getManager(), workPlan.getContact(),
+                dto.getTomorrowPlan()
+        );
+
+        // [REPORT_006] 6단계 : 명일 스케줄 투입 인원 연동 기능
+        // feat : 명일 투입 예정 인원 세팅 및 JPA 부모 매핑(workPlan) 추가
+        if (dto.getTomorrowWorkerCount() != null && dto.getTomorrowWorkerCount() > 0) {
+            WorkPlanWorker worker = WorkPlanWorker.builder()
+                    .workPlan(tomorrowPlan)
+                    .trade(WorkerTrade.COMMON)
+                    .count(dto.getTomorrowWorkerCount())
+                    .build();
+            tomorrowPlan.replaceWorkers(List.of(worker));
+        } else {
+            tomorrowPlan.replaceWorkers(new ArrayList<>());
+        }
+
+        // [REPORT_007] 7단계 : 명일 스케줄 투입 장비 연동 기능
+        // feat : 명일 투입 예정 장비 세팅 및 JPA 부모 매핑(workPlan) 추가
+        if (dto.getTomorrowEquipments() != null && !dto.getTomorrowEquipments().isEmpty()) {
+            List<WorkPlanEquipment> eqList = dto.getTomorrowEquipments().stream().map(eq -> {
+                EquipmentType type = null;
+                try {
+                    type = EquipmentType.valueOf(eq.getType());
+                } catch (Exception e) {
+                    try {
+                        type = EquipmentType.fromLabel(eq.getType());
+                    } catch (Exception ex) {
+                        // feat : 유효하지 않은 장비명일 경우 null 반환하여 저장 방지
+                        return null;
+                    }
+                }
+                if (type == null) return null;
+
+                return WorkPlanEquipment.builder()
+                        .workPlan(tomorrowPlan)
+                        .type(type)
+                        .count(eq.getCount())
+                        .build();
+            }).filter(java.util.Objects::nonNull).collect(Collectors.toList());
+            tomorrowPlan.replaceEquipment(eqList);
+        } else {
+            tomorrowPlan.replaceEquipment(new ArrayList<>());
+        }
+
+        workPlanRepository.save(tomorrowPlan);
+
+        return savedReport.getIdx();
+    }
+
+    // [REPORT_002] 2단계 : 특정 일자 공사일보 목록 조회 기능
+    // feat : 특정 날짜의 공사일보 목록을 조회하여 프론트엔드 응답용 DTO로 변환
+    @Transactional(readOnly = true)
+    public List<ReportDto.Res> getReportsByDate(LocalDate date) {
+        return dailyReportRepository.findByReportDate(date).stream().map(r ->
+                ReportDto.Res.builder()
+                        .idx(r.getIdx())
+                        .workPlanId(r.getWorkPlan().getIdx())
+                        .process(r.getWorkPlan().getTrade() != null ? r.getWorkPlan().getTrade().getLabel() : "")
+                        .actualProgress(r.getActualProgress())
+                        .todayProgress(r.getTodayProgress())
+                        .actualWorkerCount(r.getActualWorkerCount())
+                        .issue(r.getIssue())
+                        .reportDate(r.getReportDate())
+                        .todayWork(r.getTodayWork())
+                        .tomorrowPlan(r.getTomorrowPlan())
+                        .build()
+        ).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/org/example/dndn/report/model/DailyReport.java
+++ b/src/main/java/org/example/dndn/report/model/DailyReport.java
@@ -1,0 +1,50 @@
+package org.example.dndn.report.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import java.time.LocalDate;
+
+// [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
+// feat : 공사일보 엔티티 클래스
+@Entity
+@Table(name = "daily_report")
+@Getter @Builder @NoArgsConstructor @AllArgsConstructor
+public class DailyReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx; // feat : 공사일보 고유 식별자 PK
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "work_plan_idx")
+    private WorkPlan workPlan; // feat : 연관된 주간 작업 계획 FK
+
+    private Double actualProgress; // feat : 전체 누적 진척률
+
+    private Double todayProgress; // feat : 금일 입력 진척률 (새로 추가된 컬럼)
+
+    private Integer actualWorkerCount; // feat : 금일 실제 투입 인원 수
+
+    private String issue; // feat : 특이사항 및 이슈
+
+    private LocalDate reportDate; // feat : 공사일보 작성 일자
+
+    @Column(columnDefinition = "TEXT")
+    private String todayWork; // feat : 금일 작업 완료 내용
+
+    @Column(columnDefinition = "TEXT")
+    private String tomorrowPlan; // feat : 명일 작업 예정 내용
+
+    // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
+    // feat : 공사일보 정보 업데이트 메서드 (금일 진척률 반영)
+    public void updateReport(Double actualProgress, Double todayProgress, Integer actualWorkerCount, String issue, String todayWork, String tomorrowPlan) {
+        this.actualProgress = actualProgress;
+        this.todayProgress = todayProgress;
+        this.actualWorkerCount = actualWorkerCount;
+        this.issue = issue;
+        this.todayWork = todayWork;
+        this.tomorrowPlan = tomorrowPlan;
+    }
+}

--- a/src/main/java/org/example/dndn/report/model/ReportDto.java
+++ b/src/main/java/org/example/dndn/report/model/ReportDto.java
@@ -1,0 +1,66 @@
+package org.example.dndn.report.model;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.util.List;
+
+// feat : 공사일보 데이터 전송 및 반환용 DTO 클래스
+public class ReportDto {
+
+    // [REPORT_007] 7단계 : 명일 스케줄 투입 장비 연동 기능
+    // feat : 프론트에서 명일 투입 장비 배열을 받기 위한 DTO 클래스
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    public static class TomorrowEqDto {
+        private String type;    // feat : 장비 종류 (예: 굴삭기, 덤프트럭 등)
+        private Integer count;  // feat : 투입 장비 대수
+    }
+
+    // [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
+    // feat : 프론트에서 백엔드로 공사일보 데이터를 생성/요청하기 위한 DTO 클래스 (Req)
+    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    public static class Req {
+        @NotNull(message = "workPlanId is required")
+        private Long workPlanId;            // feat : 연관된 작업 계획(WorkPlan) 고유 식별자 FK
+
+        @NotNull(message = "actualProgress is required")
+        private Double actualProgress;      // feat : 계산 완료된 전체 누적 진척률 (예: 12.5%)
+
+        private Double todayProgress;       // feat : 금일 입력된 진척률 (예: 사용자가 입력한 90%)
+
+        @NotNull(message = "actualWorkerCount is required")
+        private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
+
+        @NotBlank(message = "issue is required")
+        private String issue;               // feat : 특이사항 및 이슈
+
+        @NotNull(message = "reportDate is required")
+        private LocalDate reportDate;       // feat : 공사일보 작성 일자
+
+        private String todayWork;           // feat : 금일 작업 완료 내용
+        private String tomorrowPlan;        // feat : 명일 작업 예정 내용
+
+        // [REPORT_006] 6단계 : 명일 스케줄 투입 인원 연동 기능
+        // feat : 옵션 B 추가 데이터 (내일 일정 자동 생성용)
+        private Integer tomorrowWorkerCount; // feat : 명일 투입 예정 인원 수
+
+        // [REPORT_007] 7단계 : 명일 스케줄 투입 장비 연동 기능
+        private List<TomorrowEqDto> tomorrowEquipments; // feat : 명일 투입 예정 장비 목록 배열
+    }
+
+    // [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
+    // feat : 프론트로 데이터를 반환하기 위한 응답용 DTO 클래스 (Res)
+    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    public static class Res {
+        private Long idx;                   // feat : 공사일보 고유 식별자 PK
+        private Long workPlanId;            // feat : 연관된 작업 계획 고유 식별자 FK
+        private String process;             // feat : 공정명 (예: 전기 공정)
+        private Double actualProgress;      // feat : 전체 누적 진척률
+        private Double todayProgress;       // feat : 금일 입력된 진척률
+        private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
+        private String issue;               // feat : 특이사항 및 이슈
+        private LocalDate reportDate;       // feat : 공사일보 작성 일자
+        private String todayWork;           // feat : 금일 작업 완료 내용
+        private String tomorrowPlan;        // feat : 명일 작업 예정 내용
+    }
+}


### PR DESCRIPTION
## :hammer_and_wrench: 작업 내용
- 공사일보 작성 기능 추가
- 공사일보 목록 조회 기능 추가
- 투입 인원 및 투입 장비 연동 기능 추가

## :clipboard: 상세 내용
- 공사일보 등록 및 조회 로직 구현
- 작업일 기준 공사일보 목록 조회 기능 추가
- 작업지시서/주간 계획과 연동하여 작업 스케줄 정보 불러오기
- 실제 투입 인원 정보 등록 및 조회 기능 추가
- 실제 투입 장비 정보 등록 및 조회 기능 추가
- 공사일보 데이터를 통해 실제 작업 수행 결과를 관리할 수 있는 구조 구성

## :white_check_mark: 테스트 내용
- 공사일보 등록 확인
- 공사일보 목록 조회 확인
- 작업일 기준 조회 확인
- 투입 인원 연동 확인
- 투입 장비 연동 확인

## :pushpin: 참고 사항
- 공사일보 데이터는 추후 실제 진척률 계산 및 지연 감지 기능에 활용될 예정
- 주간 계획 및 작업지시서와 연결되어 계획 대비 실제 수행 결과를 비교하는 기준 데이터로 사용할 예정

closed #165 
closed #166 
closed #167 
