### PR TITLE
[Feat] 공정 분석 API 및 일정 변경 요청 기능 구현

### DIFF
--- a/src/main/java/org/example/dndn/analysis/AnalysisController.java
+++ b/src/main/java/org/example/dndn/analysis/AnalysisController.java
@@ -1,0 +1,41 @@
+package org.example.dndn.analysis;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.common.model.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/analysis")
+@RequiredArgsConstructor
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+
+    // 공정 진척률 비교
+    // GET /analysis/progress?projectId=1
+    @GetMapping("/progress")
+    public ResponseEntity<?> progress(@RequestParam("projectId") Long projectId) {
+        return ResponseEntity.ok(BaseResponse.success(
+                analysisService.getProgressList(projectId)));
+    }
+
+//    // 지연 위험 작업 목록
+//    // GET /analysis/delay-risks?projectId=1
+//    @GetMapping("/delay-risks")
+//    public ResponseEntity<?> delayRisks(@RequestParam("projectId") Long projectId) {
+//        return ResponseEntity.ok(BaseResponse.success(
+//                analysisService.getDelayRisks(projectId)));
+//    }
+
+    // 세부 작업 지연 위험 목록
+    @GetMapping("/delay-risk-tasks")
+    public ResponseEntity<?> delayRiskTasks(
+            @RequestParam("projectId") Long projectId,
+            @RequestParam(value = "tradeProcessId", required = false) Long tradeProcessId
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(
+                analysisService.getDelayRiskTasks(projectId, tradeProcessId)
+        ));
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/AnalysisService.java
+++ b/src/main/java/org/example/dndn/analysis/AnalysisService.java
@@ -1,0 +1,502 @@
+package org.example.dndn.analysis;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.analysis.model.AnalysisDto;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.project.repository.TradeProcessRepository;
+import org.example.dndn.report.DailyReportRepository;
+import org.example.dndn.report.model.DailyReport;
+import org.example.dndn.workplan.WorkPlanRepository;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalysisService {
+
+    private static final String ACTUAL_SOURCE_DAILY_REPORT = "DAILY_REPORT";
+    private static final String ACTUAL_SOURCE_NONE = "NONE";
+
+    private final TradeProcessRepository tradeProcessRepository;
+    private final WorkPlanRepository workPlanRepository;
+    private final DailyReportRepository dailyReportRepository;
+
+    // ─────────────────────────────────────────────
+    // 1. 공정 진척률 비교
+    // TradeProcess 기준
+    // 예: 기초 콘크리트 타설 전체 진척률
+    // ─────────────────────────────────────────────
+
+    public List<AnalysisDto.ProcessProgressRes> getProgressList(Long projectId) {
+        LocalDate today = LocalDate.now();
+
+        return tradeProcessRepository
+                .findAllByMasterSchedule_Project_Idx(projectId)
+                .stream()
+                .map(tp -> buildProgressRes(tp, today))
+                .toList();
+    }
+
+    private AnalysisDto.ProcessProgressRes buildProgressRes(TradeProcess tp, LocalDate today) {
+        double plannedPct = calcPlannedPct(tp.getPlannedStart(), tp.getPlannedEnd(), today);
+        ActualProgressSnapshot actualProgress = calcActualProgressByTradeProcess(tp.getIdx(), today);
+        double actualPct = actualProgress.actualPct();
+        double diff = roundPct(plannedPct - actualPct);
+
+        String status = classifyStatus(
+                diff,
+                tp.getPlannedStart(),
+                tp.getPlannedEnd(),
+                today,
+                actualPct
+        );
+
+        String risk = classifyRisk(
+                diff,
+                tp.getPlannedStart(),
+                tp.getPlannedEnd(),
+                today,
+                actualPct
+        );
+
+        return AnalysisDto.ProcessProgressRes.builder()
+                .tradeProcessId(tp.getIdx())
+                .tradeName(tp.getTradeName())
+                .name(tp.getProcessName())
+                .partner(tp.getPartnerCompany())
+                .plannedStart(tp.getPlannedStart())
+                .plannedEnd(tp.getPlannedEnd())
+                .actualStart(tp.getPlannedStart())
+                .forecastEnd(calcForecastEnd(tp.getPlannedStart(), tp.getPlannedEnd(), actualPct, today))
+                .plannedPct(plannedPct)
+                .actualPct(actualPct)
+                .actualSource(actualProgress.source())
+                .latestReportDate(actualProgress.reportDate())
+                .diff(diff)
+                .status(status)
+                .risk(risk)
+                .actualWorkers(calcActualWorkersByTradeProcess(tp.getIdx(), today))
+                .build();
+    }
+
+    // ─────────────────────────────────────────────
+    // 2. 지연 위험 세부 작업
+    // MONTHLY WorkPlan 기준
+    // 예: 101동 기초 콘크리트 타설
+    //
+    // 자식 WEEKLY WorkPlan
+    // 예: 5/1 점검, 5/2 장비 반입, 5/3 1구간 타설
+    // ─────────────────────────────────────────────
+
+    public List<AnalysisDto.DelayRiskDetailRes> getDelayRiskTasks(Long projectId, Long tradeProcessId) {
+        LocalDate today = LocalDate.now();
+
+        return workPlanRepository
+                .findAllByTradeProcess_MasterSchedule_Project_Idx(projectId)
+                .stream()
+                // 101동 기초 콘크리트 타설 같은 세부 작업
+                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+
+                // 특정 공정 선택 시 해당 공정의 세부 작업만 조회
+                .filter(wp -> tradeProcessId == null
+                        || (wp.getTradeProcess() != null
+                        && wp.getTradeProcess().getIdx().equals(tradeProcessId)))
+
+                .map(parentPlan -> buildDelayRiskTaskRes(parentPlan, today))
+                .filter(task -> isDelayRiskTask(
+                        task.getDate(),
+                        task.getEffectiveEnd(),
+                        today,
+                        task.getDiff(),
+                        task.getActualPct()
+                ))
+                .toList();
+    }
+
+    private AnalysisDto.DelayRiskDetailRes buildDelayRiskTaskRes(WorkPlan parentPlan, LocalDate today) {
+        double plannedPct = calcPlannedPct(
+                parentPlan.getStartDate(),
+                parentPlan.effectiveEndDate(),
+                today
+        );
+
+        ActualProgressSnapshot actualProgress = getActualProgressByMonthlyPlan(parentPlan, today);
+        double actualPct = actualProgress.actualPct();
+        double diff = roundPct(plannedPct - actualPct);
+
+        String status = classifyStatus(
+                diff,
+                parentPlan.getStartDate(),
+                parentPlan.effectiveEndDate(),
+                today,
+                actualPct
+        );
+
+        String risk = classifyRisk(
+                diff,
+                parentPlan.getStartDate(),
+                parentPlan.effectiveEndDate(),
+                today,
+                actualPct
+        );
+
+        List<WorkPlan> childPlans = workPlanRepository.findAllByParentWorkPlan_Idx(parentPlan.getIdx());
+
+        int actualWorkers = childPlans.stream()
+                .mapToInt(child -> getLatestActualWorkersByWorkPlan(child.getIdx(), today))
+                .sum();
+
+        String latestIssue = getLatestIssueFromChildPlans(parentPlan.getIdx(), today);
+        String cause = actualProgress.hasDailyReport()
+                ? latestIssue
+                : "공사일보의 월간 세부계획 진척률 미작성";
+
+        return AnalysisDto.DelayRiskDetailRes.builder()
+                .workPlanId(parentPlan.getIdx())
+                .tradeProcessId(parentPlan.getTradeProcess() != null
+                        ? parentPlan.getTradeProcess().getIdx()
+                        : null)
+                .process(resolveProcessName(parentPlan))
+                .tradeName(parentPlan.getTradeProcess() != null
+                        ? parentPlan.getTradeProcess().getTradeName()
+                        : parentPlan.getTrade() != null ? parentPlan.getTrade().name() : "")
+                .name(parentPlan.getName())
+                .location(parentPlan.getLocation())
+                .partner(resolvePartner(parentPlan))
+                .date(parentPlan.getStartDate())
+                .plannedStart(parentPlan.getStartDate())
+                .plannedEnd(parentPlan.effectiveEndDate())
+                .originalEnd(parentPlan.getEndDate())
+                .effectiveEnd(parentPlan.effectiveEndDate())
+                .plannedPct(plannedPct)
+                .actualPct(actualPct)
+                .actualSource(actualProgress.source())
+                .latestReportDate(actualProgress.reportDate())
+                .dailyReportId(actualProgress.reportId())
+                .diff(diff)
+                .status(status)
+                .risk(risk)
+                .expectedDelayDays(calcExpectedDelayDays(
+                        parentPlan.getStartDate(),
+                        parentPlan.effectiveEndDate(),
+                        plannedPct,
+                        actualPct
+                ))
+                .cause(cause)
+                .followEffect(resolveFollowEffect(parentPlan, risk))
+                .isCritical(parentPlan.getTradeProcess() != null
+                        && Boolean.TRUE.equals(parentPlan.getTradeProcess().getIsMilestone()))
+                .workersDisplay(parentPlan.workersDisplay())
+                .equipmentDisplay(parentPlan.equipmentDisplay())
+                .actualWorkers(actualWorkers)
+                .hasReport(actualProgress.hasDailyReport())
+                .build();
+    }
+
+    // ─────────────────────────────────────────────
+    // 3. 실제 진척률 계산
+    // ─────────────────────────────────────────────
+
+    private ActualProgressSnapshot calcActualProgressByTradeProcess(Long tradeProcessId, LocalDate today) {
+        List<WorkPlan> plans = workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId);
+
+        if (plans.isEmpty()) return ActualProgressSnapshot.none();
+
+        List<ActualProgressSnapshot> snapshots = plans.stream()
+                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .map(wp -> getActualProgressByMonthlyPlan(wp, today))
+                .filter(ActualProgressSnapshot::hasDailyReport)
+                .toList();
+
+        if (snapshots.isEmpty()) return ActualProgressSnapshot.none();
+
+        double avg = snapshots.stream()
+                .mapToDouble(ActualProgressSnapshot::actualPct)
+                .average()
+                .orElse(0.0);
+
+        LocalDate latestReportDate = snapshots.stream()
+                .map(ActualProgressSnapshot::reportDate)
+                .filter(date -> date != null)
+                .max(LocalDate::compareTo)
+                .orElse(null);
+
+        return ActualProgressSnapshot.dailyReport(roundPct(avg), latestReportDate, null);
+    }
+
+    private ActualProgressSnapshot getActualProgressByMonthlyPlan(WorkPlan monthlyPlan, LocalDate today) {
+        if (monthlyPlan == null) return ActualProgressSnapshot.none();
+
+        return dailyReportRepository
+                .findTopByMonthlyWorkPlan_IdxAndReportDateLessThanEqualOrderByReportDateDesc(
+                        monthlyPlan.getIdx(),
+                        today
+                )
+                .map(this::toActualProgressSnapshot)
+                .orElseGet(ActualProgressSnapshot::none);
+    }
+
+    private ActualProgressSnapshot toActualProgressSnapshot(DailyReport report) {
+        Double progress = report.getMonthlyProgressPct();
+        if (progress == null) {
+            progress = report.getActualProgress();
+        }
+
+        if (progress == null) {
+            return ActualProgressSnapshot.none(report.getReportDate(), report.getIdx());
+        }
+
+        return ActualProgressSnapshot.dailyReport(
+                toPercent(progress),
+                report.getReportDate(),
+                report.getIdx()
+        );
+    }
+
+    private double toPercent(Double progress) {
+        if (progress == null) return 0.0;
+        double clamped = Math.max(0.0, Math.min(100.0, progress));
+        return roundPct(clamped);
+    }
+
+    // ─────────────────────────────────────────────
+    // 4. 실제 투입 인원 / 이슈
+    // ─────────────────────────────────────────────
+
+    private int calcActualWorkersByTradeProcess(Long tradeProcessId, LocalDate today) {
+        return workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId)
+                .stream()
+                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .flatMap(parent -> workPlanRepository.findAllByParentWorkPlan_Idx(parent.getIdx()).stream())
+                .mapToInt(child -> getLatestActualWorkersByWorkPlan(child.getIdx(), today))
+                .sum();
+    }
+
+    private int getLatestActualWorkersByWorkPlan(Long workPlanId, LocalDate today) {
+        return dailyReportRepository
+                .findTopByWorkPlan_IdxAndReportDateLessThanEqualOrderByReportDateDesc(
+                        workPlanId,
+                        today
+                )
+                .map(r -> r.getActualWorkerCount() != null ? r.getActualWorkerCount() : 0)
+                .orElse(0);
+    }
+
+    private String getLatestIssueFromChildPlans(Long parentWorkPlanId, LocalDate today) {
+        List<WorkPlan> childPlans = workPlanRepository.findAllByParentWorkPlan_Idx(parentWorkPlanId);
+
+        if (childPlans.isEmpty()) {
+            return getLatestIssueByWorkPlan(parentWorkPlanId, today);
+        }
+
+        return childPlans.stream()
+                .map(child -> getLatestIssueByWorkPlan(child.getIdx(), today))
+                .filter(issue -> issue != null && !issue.isBlank())
+                .findFirst()
+                .orElse("");
+    }
+
+    private String getLatestIssueByWorkPlan(Long workPlanId, LocalDate today) {
+        return dailyReportRepository
+                .findTopByWorkPlan_IdxAndReportDateLessThanEqualOrderByReportDateDesc(
+                        workPlanId,
+                        today
+                )
+                .map(DailyReport::getIssue)
+                .orElse("");
+    }
+
+    // ─────────────────────────────────────────────
+    // 5. 계획 진척률 / 예상 종료일
+    // ─────────────────────────────────────────────
+
+    private double calcPlannedPct(LocalDate start, LocalDate end, LocalDate today) {
+        if (start == null || end == null) return 0.0;
+
+        if (today.isBefore(start)) return 0.0;
+        if (today.isAfter(end)) return 100.0;
+
+        long totalDays = ChronoUnit.DAYS.between(start, end) + 1;
+        long elapsedDays = ChronoUnit.DAYS.between(start, today) + 1;
+
+        if (totalDays <= 0) return 100.0;
+
+        return roundPct(elapsedDays * 100.0 / totalDays);
+    }
+
+    private LocalDate calcForecastEnd(LocalDate start, LocalDate plannedEnd, double actualPct, LocalDate today) {
+        if (start == null || plannedEnd == null) return plannedEnd;
+        if (actualPct <= 0) return plannedEnd;
+        if (actualPct >= 100) return today;
+
+        long elapsedDays = ChronoUnit.DAYS.between(start, today) + 1;
+        if (elapsedDays <= 0) return plannedEnd;
+
+        double daysPerPct = elapsedDays / (double) actualPct;
+        long remainingDays = Math.round(daysPerPct * (100 - actualPct));
+
+        return today.plusDays(remainingDays);
+    }
+
+    private int calcExpectedDelayDays(LocalDate start, LocalDate end, double plannedPct, double actualPct) {
+        double lack = Math.max(0.0, plannedPct - actualPct);
+        if (lack <= 0) return 0;
+
+        long totalDays = start != null && end != null
+                ? ChronoUnit.DAYS.between(start, end) + 1
+                : 0;
+        if (totalDays <= 0) return 1;
+
+        double dailyPct = 100.0 / totalDays;
+        return Math.max(1, (int) Math.ceil(lack / dailyPct));
+    }
+
+    private double roundPct(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    private String resolveProcessName(WorkPlan workPlan) {
+        if (workPlan == null) return "";
+        if (workPlan.getTradeProcess() != null && workPlan.getTradeProcess().getTradeName() != null) {
+            return workPlan.getTradeProcess().getTradeName();
+        }
+        return workPlan.getTrade() != null ? workPlan.getTrade().name() : "";
+    }
+
+    private String resolvePartner(WorkPlan workPlan) {
+        if (workPlan == null) return "-";
+        if (workPlan.getPartner() != null && !workPlan.getPartner().isBlank()) {
+            return workPlan.getPartner();
+        }
+        if (workPlan.getTradeProcess() != null
+                && workPlan.getTradeProcess().getPartnerCompany() != null
+                && !workPlan.getTradeProcess().getPartnerCompany().isBlank()) {
+            return workPlan.getTradeProcess().getPartnerCompany();
+        }
+        return "-";
+    }
+
+    private String resolveFollowEffect(WorkPlan workPlan, String risk) {
+        if ("매우 높음".equals(risk) || "높음".equals(risk)) {
+            return "후속 공정 영향 검토 필요";
+        }
+        return "영향 낮음";
+    }
+
+    // ─────────────────────────────────────────────
+    // 6. 상태 / 위험도 판단
+    // ─────────────────────────────────────────────
+
+    private String classifyStatus(double diff, LocalDate start, LocalDate end, LocalDate today, double actualPct) {
+        if (actualPct >= 100) return "완료";
+
+        if (isOverdueNotDone(end, today, actualPct)) return "지연";
+        if (diff >= 15) return "지연";
+        if (diff >= 10) return "지연 위험";
+        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "지연 위험";
+        if (diff >= 5) return "주의";
+        if (diff > 0) return "주의";
+
+        return "정상";
+    }
+
+    private String classifyRisk(double diff, LocalDate start, LocalDate end, LocalDate today, double actualPct) {
+        if (actualPct >= 100) return "낮음";
+
+        if (isOverdueNotDone(end, today, actualPct)) return "매우 높음";
+        if (diff >= 20) return "매우 높음";
+        if (diff >= 15) return "높음";
+        if (diff >= 10) return "보통";
+        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "보통";
+        if (diff > 0) return "보통";
+
+        return "낮음";
+    }
+
+    private boolean isDelayRiskTask(
+            LocalDate start,
+            LocalDate end,
+            LocalDate today,
+            Double diff,
+            Double actualPct
+    ) {
+        double safeDiff = diff != null ? diff : 0.0;
+        double safeActualPct = actualPct != null ? actualPct : 0.0;
+
+        if (start == null || end == null) return false;
+
+        // 아직 시작 전인 세부 작업은 지연 위험으로 보지 않음
+        if (today.isBefore(start)) return false;
+
+        return safeDiff > 0
+                || isNearDeadlineAndLow(start, end, today, safeActualPct)
+                || isOverdueNotDone(end, today, safeActualPct);
+    }
+
+    private boolean isNearDeadlineAndLow(LocalDate start, LocalDate end, LocalDate today, double actualPct) {
+        if (start == null || end == null) return false;
+        if (today.isBefore(start)) return false;
+        if (actualPct >= 100) return false;
+
+        long daysLeft = ChronoUnit.DAYS.between(today, end);
+
+        return daysLeft >= 0 && daysLeft <= 3 && actualPct < 70;
+    }
+
+    private boolean isOverdueNotDone(LocalDate end, LocalDate today, double actualPct) {
+        return end != null && today.isAfter(end) && actualPct < 100;
+    }
+
+    private static class ActualProgressSnapshot {
+        private final double actualPct;
+        private final String source;
+        private final LocalDate reportDate;
+        private final Long reportId;
+
+        private ActualProgressSnapshot(double actualPct, String source, LocalDate reportDate, Long reportId) {
+            this.actualPct = actualPct;
+            this.source = source;
+            this.reportDate = reportDate;
+            this.reportId = reportId;
+        }
+
+        private static ActualProgressSnapshot dailyReport(double actualPct, LocalDate reportDate, Long reportId) {
+            return new ActualProgressSnapshot(actualPct, ACTUAL_SOURCE_DAILY_REPORT, reportDate, reportId);
+        }
+
+        private static ActualProgressSnapshot none() {
+            return new ActualProgressSnapshot(0.0, ACTUAL_SOURCE_NONE, null, null);
+        }
+
+        private static ActualProgressSnapshot none(LocalDate reportDate, Long reportId) {
+            return new ActualProgressSnapshot(0.0, ACTUAL_SOURCE_NONE, reportDate, reportId);
+        }
+
+        private double actualPct() {
+            return actualPct;
+        }
+
+        private String source() {
+            return source;
+        }
+
+        private LocalDate reportDate() {
+            return reportDate;
+        }
+
+        private Long reportId() {
+            return reportId;
+        }
+
+        private boolean hasDailyReport() {
+            return ACTUAL_SOURCE_DAILY_REPORT.equals(source);
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/ScheduleChangeController.java
+++ b/src/main/java/org/example/dndn/analysis/ScheduleChangeController.java
@@ -1,0 +1,68 @@
+package org.example.dndn.analysis;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.common.model.BaseResponse;
+import org.example.dndn.analysis.model.ScheduleChangeDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/schedule-change-request")
+@RequiredArgsConstructor
+public class ScheduleChangeController {
+
+    private final ScheduleChangeService scheduleChangeService;
+
+    // 변경 요청 등록 (공정 책임자)
+    @PostMapping
+    public ResponseEntity<?> create(@RequestBody ScheduleChangeDto.Req dto) {
+        Long newIdx = scheduleChangeService.create(dto);
+        return ResponseEntity.ok(BaseResponse.success(newIdx));
+    }
+
+    // 변경 요청 목록
+    // GET /schedule-change-request?projectId=1&process=철근&requester=김철수
+    @GetMapping
+    public ResponseEntity<?> list(
+            @RequestParam("projectId") Long projectId,
+            @RequestParam(value = "process", required = false) String process,
+            @RequestParam(value = "requester", required = false) String requester) {
+        return ResponseEntity.ok(BaseResponse.success(
+                scheduleChangeService.listRequests(projectId, process, requester)));
+    }
+
+    // 변경 이력 (처리 완료된 것만)
+    // GET /schedule-change-request/history?projectId=1&process=철근
+    @GetMapping("/history")
+    public ResponseEntity<?> history(
+            @RequestParam("projectId") Long projectId,
+            @RequestParam(value = "process", required = false) String process) {
+        return ResponseEntity.ok(BaseResponse.success(
+                scheduleChangeService.listHistory(projectId, process)));
+    }
+
+    // 승인 (총 책임자)
+    @PutMapping("/{requestId}/approve")
+    public ResponseEntity<?> approve(
+            @PathVariable("requestId") Long requestId,
+            @RequestBody ScheduleChangeDto.ApproveReq dto) {
+        scheduleChangeService.approve(requestId, dto);
+        return ResponseEntity.ok(BaseResponse.success("승인되었습니다."));
+    }
+
+    // 반려 (총 책임자)
+    @PutMapping("/{requestId}/reject")
+    public ResponseEntity<?> reject(
+            @PathVariable("requestId") Long requestId,
+            @RequestBody ScheduleChangeDto.RejectReq dto) {
+        scheduleChangeService.reject(requestId, dto);
+        return ResponseEntity.ok(BaseResponse.success("반려되었습니다."));
+    }
+
+    // 공정표 반영 (총 책임자 — APPROVED 상태에서만 가능)
+    @PutMapping("/{requestId}/apply")
+    public ResponseEntity<?> apply(@PathVariable("requestId") Long requestId) {
+        scheduleChangeService.applyToSchedule(requestId);
+        return ResponseEntity.ok(BaseResponse.success("공정표에 반영되었습니다."));
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/ScheduleChangeRepository.java
+++ b/src/main/java/org/example/dndn/analysis/ScheduleChangeRepository.java
@@ -1,0 +1,41 @@
+package org.example.dndn.analysis;
+
+import org.example.dndn.analysis.model.ScheduleChange;
+import org.example.dndn.analysis.model.ScheduleChangeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ScheduleChangeRepository extends JpaRepository<ScheduleChange, Long> {
+
+    // 현장별 전체 목록 (총 책임자 뷰)
+    List<ScheduleChange> findAllByProject_IdxOrderByCreatedAtDesc(Long projectId);
+
+    List<ScheduleChange> findAllByProject_IdxAndStatusInOrderByCreatedAtDesc(
+            Long projectId, List<ScheduleChangeStatus> statuses);
+
+    // 현장 + 공종 필터 (총 책임자 공종 필터)
+    List<ScheduleChange> findAllByProject_IdxAndProcessOrderByCreatedAtDesc(Long projectId, String process);
+
+    List<ScheduleChange> findAllByProject_IdxAndProcessAndStatusInOrderByCreatedAtDesc(
+            Long projectId, String process, List<ScheduleChangeStatus> statuses);
+
+    // 현장 + 공종 + 상태 필터
+    List<ScheduleChange> findAllByProject_IdxAndProcessAndStatusOrderByCreatedAtDesc(
+            Long projectId, String process, ScheduleChangeStatus status);
+
+    // 공정 책임자 본인 요청 목록 (requester 기준)
+    List<ScheduleChange> findAllByProject_IdxAndProcessAndRequesterOrderByCreatedAtDesc(
+            Long projectId, String process, String requester);
+
+    List<ScheduleChange> findAllByProject_IdxAndProcessAndRequesterAndStatusInOrderByCreatedAtDesc(
+            Long projectId, String process, String requester, List<ScheduleChangeStatus> statuses);
+
+    // 이력 조회 (처리 완료된 것만)
+    List<ScheduleChange> findAllByProject_IdxAndStatusInOrderByProcessedAtDesc(
+            Long projectId, List<ScheduleChangeStatus> statuses);
+
+    // 공종 필터 + 이력
+    List<ScheduleChange> findAllByProject_IdxAndProcessAndStatusInOrderByProcessedAtDesc(
+            Long projectId, String process, List<ScheduleChangeStatus> statuses);
+}

--- a/src/main/java/org/example/dndn/analysis/ScheduleChangeService.java
+++ b/src/main/java/org/example/dndn/analysis/ScheduleChangeService.java
@@ -1,0 +1,580 @@
+package org.example.dndn.analysis;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.analysis.model.ScheduleChange;
+import org.example.dndn.analysis.model.ScheduleChangeDto;
+import org.example.dndn.analysis.model.ScheduleChangeStatus;
+import org.example.dndn.project.repository.ProjectRepository;
+import org.example.dndn.project.repository.TradeProcessRepository;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.workplan.WorkPlanRepository;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.entity.WorkPlanExtension;
+import org.example.dndn.workplan.model.entity.WorkPlanWorker;
+import org.example.dndn.workplan.model.enums.WorkerTrade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleChangeService {
+
+    private static final String APPLIED_DETAIL_MARKER = "\u005b\uc2b9\uc778 \ubcc0\uacbd \ubc18\uc601\u005d";
+    private static final int LEGACY_WORK_PLAN_NOTE_LIMIT = 240;
+
+    private final ObjectMapper objectMapper;
+    private final ScheduleChangeRepository changeRepository;
+    private final ProjectRepository projectRepository;
+    private final TradeProcessRepository tradeProcessRepository;
+    private final WorkPlanRepository workPlanRepository;
+
+    // ── 요청 등록 (공정 책임자) ────────────────────────────────────────────
+
+    @Transactional
+    public Long create(ScheduleChangeDto.Req dto) {
+        Project project = projectRepository.findById(dto.getProjectId())
+                .orElseThrow(() -> new RuntimeException("현장을 찾을 수 없습니다."));
+
+        TradeProcess tradeProcess = null;
+        if (dto.getTradeProcessId() != null) {
+            tradeProcess = tradeProcessRepository.findById(dto.getTradeProcessId())
+                    .orElseThrow(() -> new RuntimeException("공정을 찾을 수 없습니다."));
+        }
+
+        WorkPlan workPlan = null;
+        if (dto.getWorkPlanId() != null) {
+            workPlan = workPlanRepository.findById(dto.getWorkPlanId())
+                    .orElseThrow(() -> new RuntimeException("작업 계획을 찾을 수 없습니다."));
+            if (tradeProcess == null) {
+                tradeProcess = workPlan.getTradeProcess();
+            }
+        }
+
+        String resolvedProcess = resolveProcess(dto, tradeProcess, workPlan);
+        Optional<ScheduleChange> duplicate = findDuplicatePendingRequest(
+                project.getIdx(), dto, resolvedProcess, tradeProcess, workPlan);
+        if (duplicate.isPresent()) {
+            return duplicate.get().getIdx();
+        }
+
+        String attachmentUrls = (dto.getAttachmentUrls() == null || dto.getAttachmentUrls().isEmpty())
+                ? null
+                : String.join(",", dto.getAttachmentUrls());
+
+        ScheduleChange request = ScheduleChange.builder()
+                .project(project)
+                .tradeProcess(tradeProcess)
+                .workPlan(workPlan)
+                .taskName(dto.getTaskName())
+                .requester(dto.getRequester())
+                .process(resolvedProcess)
+                .oldStart(dto.getOldStart())
+                .oldEnd(dto.getOldEnd())
+                .newStart(dto.getNewStart())
+                .newEnd(dto.getNewEnd())
+                .reason(dto.getReason())
+                .cause(dto.getCause())
+                .changeSummaryJson(toJson(dto.getChangeSummary()))
+                .detailChangesJson(toJson(dto.getDetailChanges()))
+                .aiApplied(dto.getAiApplied() != null ? dto.getAiApplied() : false)
+                .attachmentUrls(attachmentUrls)
+                .build();
+
+        return changeRepository.save(request).getIdx();
+    }
+
+    // ── 목록 조회 ──────────────────────────────────────────────────────────
+
+    /**
+     * 변경 요청 목록 — 총 책임자(전체) / 공정 책임자(본인 공종)
+     *
+     * @param projectId  현장 ID
+     * @param process    공종 필터 (null이면 전체)
+     * @param requester  본인 식별자 (null이면 전체 — 총 책임자 뷰)
+     */
+    public List<ScheduleChangeDto.Res> listRequests(
+            Long projectId, String process, String requester) {
+
+        List<ScheduleChange> requests;
+        List<ScheduleChangeStatus> activeStatuses = List.of(
+                ScheduleChangeStatus.PENDING,
+                ScheduleChangeStatus.APPROVED);
+
+        if (requester != null && !requester.isBlank()) {
+            // 공정 책임자: 본인 요청만
+            requests = changeRepository
+                    .findAllByProject_IdxAndProcessAndRequesterAndStatusInOrderByCreatedAtDesc(
+                            projectId, process, requester, activeStatuses);
+        } else if (process != null && !process.isBlank()) {
+            // 총 책임자 + 공종 필터
+            requests = changeRepository
+                    .findAllByProject_IdxAndProcessAndStatusInOrderByCreatedAtDesc(
+                            projectId, process, activeStatuses);
+        } else {
+            // 총 책임자 + 전체
+            requests = changeRepository
+                    .findAllByProject_IdxAndStatusInOrderByCreatedAtDesc(
+                            projectId, activeStatuses);
+        }
+
+        return deduplicateRequests(requests).stream().map(ScheduleChangeDto.Res::from).toList();
+    }
+
+    /**
+     * 변경 이력 — 처리 완료(APPROVED, APPLIED, REJECTED)된 항목
+     */
+    public List<ScheduleChangeDto.Res> listHistory(Long projectId, String process) {
+        List<ScheduleChangeStatus> doneStatuses = List.of(
+                ScheduleChangeStatus.APPROVED,
+                ScheduleChangeStatus.APPLIED,
+                ScheduleChangeStatus.REJECTED);
+
+        List<ScheduleChange> history = (process != null && !process.isBlank())
+                ? changeRepository
+                .findAllByProject_IdxAndProcessAndStatusInOrderByProcessedAtDesc(
+                        projectId, process, doneStatuses)
+                : changeRepository
+                .findAllByProject_IdxAndStatusInOrderByProcessedAtDesc(
+                        projectId, doneStatuses);
+
+        return history.stream().map(ScheduleChangeDto.Res::from).toList();
+    }
+
+    // ── 승인 (총 책임자) ───────────────────────────────────────────────────
+
+    @Transactional
+    public void approve(Long requestId, ScheduleChangeDto.ApproveReq dto) {
+        findRequest(requestId).approve(dto.getApprover());
+    }
+
+    // ── 반려 (총 책임자) ───────────────────────────────────────────────────
+
+    @Transactional
+    public void reject(Long requestId, ScheduleChangeDto.RejectReq dto) {
+        findRequest(requestId).reject(dto.getApprover(), dto.getRejectReason());
+    }
+
+    // ── 공정표 반영 (총 책임자) ────────────────────────────────────────────
+
+    /**
+     * 승인된 요청을 실제 공정 일정에 반영한다.
+     *
+     * 반영 대상:
+     *  1. TradeProcess (tradeProcessId가 있을 때) — applyScheduleChange()
+     *  2. 해당 TradeProcess에 연결된 WorkPlan의 WorkPlanExtension — 동기화
+     */
+    @Transactional
+    public void applyToSchedule(Long requestId) {
+        ScheduleChange request = findRequest(requestId);
+        boolean alreadyApplied = request.getStatus() == ScheduleChangeStatus.APPLIED;
+
+        if (request.getStatus() != ScheduleChangeStatus.APPROVED && !alreadyApplied) {
+            throw new IllegalStateException("승인 완료 또는 일정 반영 완료 상태에서만 공정표에 반영할 수 있습니다.");
+        }
+
+        // 1. 월간/주간 WorkPlan 기반 요청이면 해당 계획의 연장 정보만 동기화
+        if (request.getWorkPlan() != null) {
+            syncWorkPlanExtension(request.getWorkPlan(), request);
+        }
+        // 2. 공정표 공정 자체 변경 요청이면 해당 공정과 연결된 WorkPlan 동기화
+        else if (request.getTradeProcess() != null) {
+            TradeProcess tradeProcess = request.getTradeProcess();
+            tradeProcess.applyScheduleChange(request.getNewStart(), request.getNewEnd());
+
+            workPlanRepository.findAllByTradeProcess_Idx(tradeProcess.getIdx()).stream()
+                    .forEach(wp -> syncWorkPlanExtension(wp, request));
+        }
+
+        applyDetailChangesToWorkPlans(request);
+
+        // 3. 요청 상태를 APPLIED로 변경
+        if (!alreadyApplied) {
+            request.markApplied();
+        }
+    }
+
+    // ── 내부 헬퍼 ─────────────────────────────────────────────────────────
+
+    private Optional<ScheduleChange> findDuplicatePendingRequest(
+            Long projectId,
+            ScheduleChangeDto.Req dto,
+            String resolvedProcess,
+            TradeProcess tradeProcess,
+            WorkPlan workPlan) {
+
+        return changeRepository
+                .findAllByProject_IdxAndStatusInOrderByCreatedAtDesc(
+                        projectId, List.of(ScheduleChangeStatus.PENDING))
+                .stream()
+                .filter(request -> sameRequest(request, dto, resolvedProcess, tradeProcess, workPlan))
+                .findFirst();
+    }
+
+    private boolean sameRequest(
+            ScheduleChange request,
+            ScheduleChangeDto.Req dto,
+            String resolvedProcess,
+            TradeProcess tradeProcess,
+            WorkPlan workPlan) {
+
+        Long requestWorkPlanId = request.getWorkPlan() != null ? request.getWorkPlan().getIdx() : null;
+        Long dtoWorkPlanId = workPlan != null ? workPlan.getIdx() : null;
+        if (!Objects.equals(requestWorkPlanId, dtoWorkPlanId)) {
+            return false;
+        }
+
+        Long requestTradeProcessId = request.getTradeProcess() != null ? request.getTradeProcess().getIdx() : null;
+        Long dtoTradeProcessId = tradeProcess != null ? tradeProcess.getIdx() : null;
+        if (!Objects.equals(requestTradeProcessId, dtoTradeProcessId)) {
+            return false;
+        }
+
+        return sameText(request.getRequester(), dto.getRequester())
+                && sameText(request.getProcess(), resolvedProcess)
+                && sameText(request.getTaskName(), dto.getTaskName())
+                && Objects.equals(request.getOldStart(), dto.getOldStart())
+                && Objects.equals(request.getOldEnd(), dto.getOldEnd())
+                && Objects.equals(request.getNewStart(), dto.getNewStart())
+                && Objects.equals(request.getNewEnd(), dto.getNewEnd());
+    }
+
+    private List<ScheduleChange> deduplicateRequests(List<ScheduleChange> requests) {
+        Map<String, ScheduleChange> unique = new LinkedHashMap<>();
+        for (ScheduleChange request : requests) {
+            unique.putIfAbsent(deduplicateKey(request), request);
+        }
+        return new ArrayList<>(unique.values());
+    }
+
+    private String deduplicateKey(ScheduleChange request) {
+        return String.join("|",
+                text(request.getProject() != null ? request.getProject().getIdx() : null),
+                text(request.getWorkPlan() != null ? request.getWorkPlan().getIdx() : null),
+                text(request.getTradeProcess() != null ? request.getTradeProcess().getIdx() : null),
+                normalized(request.getRequester()),
+                normalized(request.getProcess()),
+                normalized(request.getTaskName()),
+                text(request.getOldStart()),
+                text(request.getOldEnd()),
+                text(request.getNewStart()),
+                text(request.getNewEnd()));
+    }
+
+    private boolean sameText(String left, String right) {
+        return normalized(left).equals(normalized(right));
+    }
+
+    private String normalized(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value);
+    }
+
+    private ScheduleChange findRequest(Long requestId) {
+        return changeRepository.findById(requestId)
+                .orElseThrow(() -> new RuntimeException("일정 변경 요청을 찾을 수 없습니다."));
+    }
+
+    private String resolveProcess(ScheduleChangeDto.Req dto, TradeProcess tradeProcess, WorkPlan workPlan) {
+        if (dto.getProcess() != null && !dto.getProcess().isBlank()) {
+            return dto.getProcess();
+        }
+        if (tradeProcess != null && tradeProcess.getTradeName() != null) {
+            return tradeProcess.getTradeName();
+        }
+        if (workPlan != null && workPlan.getTrade() != null) {
+            return workPlan.getTrade().name();
+        }
+        return "기타";
+    }
+
+    private String toJson(Object value) {
+        if (value == null) return null;
+
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("변경 검토 데이터를 JSON으로 변환할 수 없습니다.", e);
+        }
+    }
+
+    private void applyDetailChangesToWorkPlans(ScheduleChange request) {
+        List<Map<String, Object>> detailChanges = readDetailChanges(request.getDetailChangesJson());
+        if (detailChanges.isEmpty()) return;
+
+        for (Map<String, Object> detail : detailChanges) {
+            Long workPlanId = toLong(detail.get("workPlanId"));
+            if (workPlanId == null) continue;
+
+            WorkPlan workPlan = workPlanRepository.findById(workPlanId)
+                    .orElseThrow(() -> new RuntimeException("변경 대상 작업 계획을 찾을 수 없습니다. id=" + workPlanId));
+
+            applyDetailChangeToWorkPlan(workPlan, detail);
+        }
+    }
+
+    private List<Map<String, Object>> readDetailChanges(String json) {
+        if (json == null || json.isBlank()) return List.of();
+
+        try {
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new IllegalArgumentException("세부 일정 변경 데이터를 읽을 수 없습니다.", e);
+        }
+    }
+
+    private void applyDetailChangeToWorkPlan(WorkPlan workPlan, Map<String, Object> detail) {
+        String recommendedName = nonBlank(detail.get("recommendedName"), workPlan.getName());
+        String partner = nonBlank(detail.get("partner"), workPlan.getPartner());
+        String manager = nonBlank(detail.get("manager"), workPlan.getManager());
+        String contact = nonBlank(detail.get("contact"), workPlan.getContact());
+        String note = buildAppliedDetailNote(workPlan.getNote(), detail);
+
+        workPlan.updateInfo(
+                recommendedName,
+                workPlan.getTrade(),
+                workPlan.getLocation(),
+                workPlan.getStartDate(),
+                workPlan.getEndDate(),
+                workPlan.getStatus(),
+                partner,
+                manager,
+                contact,
+                note
+        );
+
+        Integer recommendedRequiredCount = toInteger(detail.get("recommendedRequiredCount"));
+        if (recommendedRequiredCount != null) {
+            applyRecommendedWorkerCount(workPlan, recommendedRequiredCount);
+        }
+    }
+
+    private void applyRecommendedWorkerCount(WorkPlan workPlan, int recommendedRequiredCount) {
+        int targetCount = Math.max(0, recommendedRequiredCount);
+        List<WorkPlanWorker> existingWorkers = workPlan.getWorkers() != null
+                ? workPlan.getWorkers()
+                : List.of();
+
+        if (targetCount == 0) {
+            workPlan.replaceWorkers(List.of());
+            return;
+        }
+
+        if (existingWorkers.isEmpty()) {
+            workPlan.replaceWorkers(List.of(WorkPlanWorker.builder()
+                    .trade(WorkerTrade.COMMON)
+                    .count(targetCount)
+                    .build()));
+            return;
+        }
+
+        List<WorkerCount> workerCounts = existingWorkers.stream()
+                .filter(worker -> worker.getTrade() != null)
+                .map(worker -> new WorkerCount(
+                        worker.getTrade(),
+                        Math.max(0, worker.getCount() != null ? worker.getCount() : 0)))
+                .toList();
+
+        if (workerCounts.isEmpty()) {
+            workPlan.replaceWorkers(List.of(WorkPlanWorker.builder()
+                    .trade(WorkerTrade.COMMON)
+                    .count(targetCount)
+                    .build()));
+            return;
+        }
+
+        int currentTotal = workerCounts.stream().mapToInt(WorkerCount::count).sum();
+        if (currentTotal <= 0) {
+            workPlan.replaceWorkers(List.of(WorkPlanWorker.builder()
+                    .trade(workerCounts.get(0).trade())
+                    .count(targetCount)
+                    .build()));
+            return;
+        }
+
+        List<WorkerCount> adjusted = new ArrayList<>(workerCounts);
+        int delta = targetCount - currentTotal;
+        if (delta >= 0) {
+            WorkerCount first = adjusted.get(0);
+            adjusted.set(0, new WorkerCount(first.trade(), first.count() + delta));
+        } else {
+            int remainingReduction = -delta;
+            for (int i = adjusted.size() - 1; i >= 0 && remainingReduction > 0; i--) {
+                WorkerCount current = adjusted.get(i);
+                int reduction = Math.min(current.count(), remainingReduction);
+                adjusted.set(i, new WorkerCount(current.trade(), current.count() - reduction));
+                remainingReduction -= reduction;
+            }
+        }
+
+        List<WorkPlanWorker> newWorkers = adjusted.stream()
+                .filter(worker -> worker.count() > 0)
+                .map(worker -> WorkPlanWorker.builder()
+                        .trade(worker.trade())
+                        .count(worker.count())
+                        .build())
+                .toList();
+
+        if (newWorkers.isEmpty()) {
+            newWorkers = List.of(WorkPlanWorker.builder()
+                    .trade(adjusted.get(0).trade())
+                    .count(targetCount)
+                    .build());
+        }
+
+        workPlan.replaceWorkers(newWorkers);
+    }
+
+    private String buildAppliedDetailNote(String originalNote, Map<String, Object> detail) {
+        List<String> lines = new ArrayList<>();
+        String baseNote = removeAppliedDetailNote(nonBlank(detail.get("recommendedNote"), originalNote));
+
+        String originalWorkTime = nonBlank(detail.get("originalWorkTime"), "");
+        String recommendedWorkTime = nonBlank(detail.get("recommendedWorkTime"), "");
+        if (!recommendedWorkTime.isBlank()) {
+            if (!originalWorkTime.isBlank() && !originalWorkTime.equals(recommendedWorkTime)) {
+                lines.add("\uc791\uc5c5\uc2dc\uac04: " + originalWorkTime + " -> " + recommendedWorkTime);
+            } else {
+                lines.add("\uc791\uc5c5\uc2dc\uac04: " + recommendedWorkTime);
+            }
+        }
+
+        Double originalManHours = toDouble(detail.get("originalManHours"));
+        Double recommendedManHours = toDouble(detail.get("recommendedManHours"));
+        if (recommendedManHours != null) {
+            String manHourLine = originalManHours != null
+                    ? "\uacf5\uc218: " + formatNumber(originalManHours) + " -> " + formatNumber(recommendedManHours) + "\uc778\uc2dc"
+                    : "\uacf5\uc218: " + formatNumber(recommendedManHours) + "\uc778\uc2dc";
+            lines.add(manHourLine);
+        }
+
+        if (lines.isEmpty()) return limitLegacyNote(baseNote);
+
+        String appliedBlock = APPLIED_DETAIL_MARKER + "\n" + String.join("\n", lines);
+        if (baseNote == null || baseNote.isBlank()) {
+            return limitLegacyNote(appliedBlock);
+        }
+        return joinLegacyNote(baseNote, appliedBlock);
+    }
+
+    private String removeAppliedDetailNote(String note) {
+        if (note == null || note.isBlank()) return note;
+
+        int markerIndex = note.indexOf(APPLIED_DETAIL_MARKER);
+        if (markerIndex < 0) return note;
+
+        return note.substring(0, markerIndex).stripTrailing();
+    }
+
+    private String joinLegacyNote(String baseNote, String appliedBlock) {
+        String normalizedBase = baseNote == null ? "" : baseNote.stripTrailing();
+        if (normalizedBase.isBlank()) return limitLegacyNote(appliedBlock);
+
+        int separatorLength = 2;
+        int availableBaseLength = LEGACY_WORK_PLAN_NOTE_LIMIT - appliedBlock.length() - separatorLength;
+        if (availableBaseLength <= 20) {
+            return limitLegacyNote(appliedBlock);
+        }
+
+        return limitLegacyNote(truncate(normalizedBase, availableBaseLength) + "\n\n" + appliedBlock);
+    }
+
+    private String limitLegacyNote(String note) {
+        return truncate(note, LEGACY_WORK_PLAN_NOTE_LIMIT);
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) return null;
+        if (text.length() <= maxLength) return text;
+        if (maxLength <= 1) return text.substring(0, maxLength);
+        return text.substring(0, maxLength - 1).stripTrailing() + "\u2026";
+    }
+
+    private String nonBlank(Object value, String fallback) {
+        if (value == null) return fallback;
+        String text = String.valueOf(value).trim();
+        return text.isBlank() ? fallback : text;
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number number) return number.longValue();
+        try {
+            String text = String.valueOf(value).trim();
+            return text.isBlank() ? null : Long.parseLong(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Integer toInteger(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number number) return number.intValue();
+        try {
+            String text = String.valueOf(value).trim();
+            return text.isBlank() ? null : Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Double toDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number number) return number.doubleValue();
+        try {
+            String text = String.valueOf(value).trim();
+            return text.isBlank() ? null : Double.parseDouble(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String formatNumber(Double value) {
+        if (value == null) return "";
+        if (Math.floor(value) == value) {
+            return String.valueOf(value.longValue());
+        }
+        return String.valueOf(Math.round(value * 10.0) / 10.0);
+    }
+
+    /**
+     * WorkPlan의 Extension을 변경 요청의 새 종료일 기준으로 동기화.
+     * 기존 Extension이 없으면 새로 생성.
+     */
+    private void syncWorkPlanExtension(WorkPlan workPlan, ScheduleChange request) {
+        WorkPlanExtension extension = workPlan.getExtension();
+        if (extension == null) {
+            extension = WorkPlanExtension.builder().build();
+            workPlan.attachExtension(extension);
+        }
+
+        int addedDays = 0;
+        if (workPlan.getEndDate() != null && request.getNewEnd() != null) {
+            addedDays = (int) java.time.temporal.ChronoUnit.DAYS
+                    .between(workPlan.getEndDate(), request.getNewEnd());
+        }
+
+        extension.update(
+                request.getNewEnd(),
+                addedDays,
+                request.getReason(),
+                LocalDate.now()
+        );
+    }
+
+    private record WorkerCount(WorkerTrade trade, int count) {}
+}

--- a/src/main/java/org/example/dndn/analysis/model/AnalysisDto.java
+++ b/src/main/java/org/example/dndn/analysis/model/AnalysisDto.java
@@ -1,0 +1,90 @@
+package org.example.dndn.analysis.model;
+
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AnalysisDto {
+
+    // ── 공정 진척률 비교 응답 ──────────────────────────────────────────────
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ProcessProgressRes {
+        private Long tradeProcessId;
+        private String tradeName;       // 대표 공종명
+        private String name;            // 공정명
+        private String partner;         // 협력사명
+        private LocalDate plannedStart;
+        private LocalDate plannedEnd;
+        private LocalDate actualStart;
+        private LocalDate forecastEnd;  // 예상 종료일 (실적 기반 추정)
+        private Double plannedPct;      // 계획 진척률 (날짜 비율)
+        private Double actualPct;       // 실제 진척률 (DailyReport 누적)
+        private String actualSource;    // DAILY_REPORT | NONE
+        private LocalDate latestReportDate;
+        private Double diff;            // plannedPct - actualPct (양수 = 지연)
+        private String status;          // 정상 / 주의 / 지연 위험 / 지연
+        private String risk;            // 낮음 / 보통 / 높음 / 매우 높음
+        private Integer actualWorkers;  // 최근 실제 투입 인원
+    }
+
+    // ── 지연 위험 작업 응답 (월간 공정 레벨) ────────────────────────────────
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class DelayRiskRes {
+        private Long tradeProcessId;
+        private Long workPlanId;            // 월간 WorkPlan ID
+        private String process;             // 공종명
+        private String name;                // 작업명
+        private String location;            // 작업 위치
+        private String partner;             // 협력사명
+        private Double plannedPct;
+        private Double actualPct;
+        private Double diff;
+        private Integer expectedDelayDays;  // 예상 지연일
+        private String risk;
+        private String cause;               // 지연 원인
+        private String followEffect;        // 후속 공정 영향 (추후 확장)
+        private Boolean isCritical;         // 임계 공정 여부
+        private LocalDate originalEnd;
+        private Integer actualWorkers;
+
+        // ── 세부 작업 (WEEKLY WorkPlan) ──────────────────────────────────
+        private List<DelayRiskDetailRes> weeklyItems;
+    }
+
+    // ── 지연 위험 세부 작업 응답 (주간/일별 WorkPlan 레벨) ──────────────────
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class DelayRiskDetailRes {
+        private Long workPlanId;            // WEEKLY WorkPlan ID
+        private Long tradeProcessId;
+        private String process;             // 대표 공종명
+        private String tradeName;           // 원본 공종명
+        private String name;                // 세부 작업명
+        private String location;            // 작업 구역
+        private String partner;             // 협력사명
+        private LocalDate date;             // 작업일 (startDate = endDate)
+        private LocalDate plannedStart;
+        private LocalDate plannedEnd;
+        private LocalDate originalEnd;      // 원래 종료일
+        private LocalDate effectiveEnd;     // 연장 포함 종료일
+        private Double plannedPct;
+        private Double actualPct;
+        private String actualSource;    // DAILY_REPORT | NONE
+        private LocalDate latestReportDate;
+        private Long dailyReportId;
+        private Double diff;
+        private String status;
+        private String risk;
+        private Integer expectedDelayDays;
+        private String cause;               // 최근 DailyReport.issue
+        private String followEffect;
+        private Boolean isCritical;
+        private String workersDisplay;      // "전공 4명, 보통공 2명"
+        private String equipmentDisplay;    // "타워크레인 1대"
+        private Integer actualWorkers;      // 실제 투입 인원
+        private Boolean hasReport;          // DailyReport 제출 여부
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/model/ScheduleChange.java
+++ b/src/main/java/org/example/dndn/analysis/model/ScheduleChange.java
@@ -1,0 +1,147 @@
+package org.example.dndn.analysis.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+
+import java.time.LocalDate;
+
+/**
+ * 일정 변경 요청 엔티티
+ *
+ * 라이프사이클:
+ *   공정 책임자 등록 (PENDING)
+ *     → 총 책임자 승인 (APPROVED) 또는 반려 (REJECTED)
+ *     → 승인 후 공정표 반영 (APPLIED)
+ *
+ * APPLIED 시 TradeProcess.applyScheduleChange() + WorkPlanExtension.update() 호출
+ */
+@Entity
+@Table(name = "schedule_change_request")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleChange extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    // ── 연관 관계 ──────────────────────────────────────────────────────────
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    /**
+     * nullable — tradeProcess 없이 등록하는 경우도 허용.
+     * AI 추천안 기반 요청은 연결, 수동 요청은 null 가능.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trade_process_id")
+    private TradeProcess tradeProcess;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "work_plan_id")
+    private WorkPlan workPlan;
+
+    // ── 요청 내용 ──────────────────────────────────────────────────────────
+
+    @Column(nullable = false)
+    private String taskName;    // 작업명 (예: "기초 철근 배근")
+
+    @Column(nullable = false)
+    private String requester;   // 요청자 표시명 (예: "김철수 (철근 책임자)")
+
+    @Column(nullable = false)
+    private String process;     // 공종명 — 필터 조회용 denormalized 컬럼
+
+    private LocalDate oldStart;
+    private LocalDate oldEnd;
+
+    @Column(nullable = false)
+    private LocalDate newStart;
+
+    @Column(nullable = false)
+    private LocalDate newEnd;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String reason;      // 변경 사유
+
+    private String cause;       // 지연 원인 (기상/인력/자재 등)
+
+    @Column(columnDefinition = "TEXT")
+    private String changeSummaryJson;   // 승인 화면 요약 데이터(JSON)
+
+    @Column(columnDefinition = "TEXT")
+    private String detailChangesJson;   // 세부일정별 변경 데이터(JSON 배열)
+
+    @Builder.Default
+    private Boolean aiApplied = false;  // AI 추천안 반영 여부
+
+    // ── 첨부파일 ──────────────────────────────────────────────────────────
+
+    /**
+     * 첨부파일 URL 목록을 콤마 구분 문자열로 저장.
+     * 파일 업로드 API와 연동 시 S3 URL 등을 여기에 저장.
+     */
+    private String attachmentUrls;
+
+    // ── 상태 / 처리 결과 ──────────────────────────────────────────────────
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ScheduleChangeStatus status = ScheduleChangeStatus.PENDING;
+
+    private String rejectReason;    // 반려 사유
+    private String approver;        // 처리자 표시명 (예: "이감독 (현장 총 책임자)")
+    private LocalDate processedAt;  // 승인/반려/반영 처리일
+
+    // ── 도메인 메서드 ──────────────────────────────────────────────────────
+
+    /**
+     * 총 책임자 승인
+     */
+    public void approve(String approver) {
+        validateStatus(ScheduleChangeStatus.PENDING, "승인");
+        this.status = ScheduleChangeStatus.APPROVED;
+        this.approver = approver;
+        this.processedAt = LocalDate.now();
+    }
+
+    /**
+     * 총 책임자 반려
+     */
+    public void reject(String approver, String rejectReason) {
+        validateStatus(ScheduleChangeStatus.PENDING, "반려");
+        if (rejectReason == null || rejectReason.isBlank()) {
+            throw new IllegalArgumentException("반려 사유는 필수입니다.");
+        }
+        this.status = ScheduleChangeStatus.REJECTED;
+        this.approver = approver;
+        this.rejectReason = rejectReason;
+        this.processedAt = LocalDate.now();
+    }
+
+    /**
+     * 공정표 반영 처리 — 실제 TradeProcess/WorkPlan 수정은 서비스에서 수행 후 호출.
+     */
+    public void markApplied() {
+        validateStatus(ScheduleChangeStatus.APPROVED, "공정표 반영");
+        this.status = ScheduleChangeStatus.APPLIED;
+        this.processedAt = LocalDate.now();
+    }
+
+    private void validateStatus(ScheduleChangeStatus required, String action) {
+        if (this.status != required) {
+            throw new IllegalStateException(
+                    String.format("'%s' 상태에서만 %s할 수 있습니다. 현재 상태: %s",
+                            required.getLabel(), action, this.status.getLabel()));
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/model/ScheduleChangeDto.java
+++ b/src/main/java/org/example/dndn/analysis/model/ScheduleChangeDto.java
@@ -1,0 +1,153 @@
+package org.example.dndn.analysis.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ScheduleChangeDto {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    // ── 요청 등록 (공정 책임자) ────────────────────────────────────────────
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Req {
+        private Long projectId;
+        private Long tradeProcessId;    // 선택 — AI 추천 기반이면 연결
+        private Long workPlanId;        // 선택 — 월간 세부계획 변경 요청이면 연결
+        private String taskName;
+        private String requester;
+        private String process;
+        private LocalDate oldStart;
+        private LocalDate oldEnd;
+        private LocalDate newStart;
+        private LocalDate newEnd;
+        private String reason;
+        private String cause;
+        private Map<String, Object> changeSummary;
+        private List<Map<String, Object>> detailChanges;
+        private Boolean aiApplied;
+        private List<String> attachmentUrls;  // 업로드 후 URL 목록
+    }
+
+    // ── 승인/반려 (총 책임자) ─────────────────────────────────────────────
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ApproveReq {
+        private String approver;    // 처리자 표시명
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class RejectReq {
+        private String approver;
+        private String rejectReason;
+    }
+
+    // ── 응답 ──────────────────────────────────────────────────────────────
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Res {
+        private Long idx;
+        private Long projectId;
+        private Long tradeProcessId;
+        private Long workPlanId;
+        private String taskName;
+        private String requester;
+        private String process;
+        private String requestDate;     // createdAt 포맷
+        private LocalDate oldStart;
+        private LocalDate oldEnd;
+        private LocalDate newStart;
+        private LocalDate newEnd;
+        private String reason;
+        private String cause;
+        private Map<String, Object> changeSummary;
+        private List<Map<String, Object>> detailChanges;
+        private Boolean aiApplied;
+        private List<String> attachmentUrls;
+        private String status;          // 프론트 상태 코드(pending/approved/applied/rejected)
+        private String statusLabel;     // 한글 라벨
+        private String rejectReason;
+        private String approver;
+        private LocalDate processedAt;
+
+        public static Res from(ScheduleChange entity) {
+            String requestDate = "";
+            if (entity.getCreatedAt() != null) {
+                requestDate = entity.getCreatedAt().toLocalDate().format(DATE_FORMATTER);
+            }
+
+            List<String> urls = Collections.emptyList();
+            if (entity.getAttachmentUrls() != null && !entity.getAttachmentUrls().isBlank()) {
+                urls = Arrays.asList(entity.getAttachmentUrls().split(","));
+            }
+
+            return Res.builder()
+                    .idx(entity.getIdx())
+                    .projectId(entity.getProject().getIdx())
+                    .tradeProcessId(entity.getTradeProcess() != null
+                            ? entity.getTradeProcess().getIdx() : null)
+                    .workPlanId(entity.getWorkPlan() != null
+                            ? entity.getWorkPlan().getIdx() : null)
+                    .taskName(entity.getTaskName())
+                    .requester(entity.getRequester())
+                    .process(entity.getProcess())
+                    .requestDate(requestDate)
+                    .oldStart(entity.getOldStart())
+                    .oldEnd(entity.getOldEnd())
+                    .newStart(entity.getNewStart())
+                    .newEnd(entity.getNewEnd())
+                    .reason(entity.getReason())
+                    .cause(entity.getCause())
+                    .changeSummary(readObject(entity.getChangeSummaryJson()))
+                    .detailChanges(readList(entity.getDetailChangesJson()))
+                    .aiApplied(entity.getAiApplied())
+                    .attachmentUrls(urls)
+                    .status(toClientStatus(entity.getStatus()))
+                    .statusLabel(entity.getStatus().getLabel())
+                    .rejectReason(entity.getRejectReason())
+                    .approver(entity.getApprover())
+                    .processedAt(entity.getProcessedAt())
+                    .build();
+        }
+
+        private static String toClientStatus(ScheduleChangeStatus status) {
+            if (status == null) return "";
+
+            return switch (status) {
+                case PENDING -> "pending";
+                case APPROVED -> "approved";
+                case APPLIED -> "applied";
+                case REJECTED -> "rejected";
+            };
+        }
+
+        private static Map<String, Object> readObject(String json) {
+            if (json == null || json.isBlank()) return null;
+
+            try {
+                return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private static List<Map<String, Object>> readList(String json) {
+            if (json == null || json.isBlank()) return Collections.emptyList();
+
+            try {
+                return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+            } catch (Exception e) {
+                return Collections.emptyList();
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/model/ScheduleChangeStatus.java
+++ b/src/main/java/org/example/dndn/analysis/model/ScheduleChangeStatus.java
@@ -1,0 +1,23 @@
+package org.example.dndn.analysis.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ScheduleChangeStatus {
+    PENDING("승인 대기"),
+    APPROVED("승인 완료"),
+    APPLIED("일정 반영 완료"),
+    REJECTED("반려");
+
+    private final String label;
+
+    public static ScheduleChangeStatus fromLabel(String label) {
+        if (label == null) return PENDING;
+        for (ScheduleChangeStatus s : values()) {
+            if (s.label.equals(label)) return s;
+        }
+        return PENDING;
+    }
+}

--- a/src/main/java/org/example/dndn/report/DailyReportRepository.java
+++ b/src/main/java/org/example/dndn/report/DailyReportRepository.java
@@ -20,4 +20,9 @@ public interface DailyReportRepository extends JpaRepository<DailyReport, Long> 
             Long workPlanId,
             LocalDate reportDate
     );
+
+    Optional<DailyReport> findTopByMonthlyWorkPlan_IdxAndReportDateLessThanEqualOrderByReportDateDesc(
+            Long monthlyWorkPlanId,
+            LocalDate reportDate
+    );
 }

--- a/src/main/java/org/example/dndn/report/DailyReportService.java
+++ b/src/main/java/org/example/dndn/report/DailyReportService.java
@@ -40,12 +40,42 @@ public class DailyReportService {
                         .reportDate(dto.getReportDate())
                         .build());
 
-        // feat : 금일 진척률을 포함하여 공사일보 정보 업데이트
-        dailyReport.updateReport(dto.getActualProgress(), dto.getTodayProgress(), dto.getActualWorkerCount(), dto.getIssue(), dto.getTodayWork(), dto.getTomorrowPlan());
+        WorkPlan monthlyPlan = null;
+        if (dto.getMonthlyWorkPlanId() != null) {
+            monthlyPlan = workPlanRepository.findById(dto.getMonthlyWorkPlanId())
+                    .orElseThrow(() -> new RuntimeException("월간 세부계획을 찾을 수 없습니다. id=" + dto.getMonthlyWorkPlanId()));
+        }
+
+        Double monthlyProgressPct = clampPercent(dto.getMonthlyProgressPct() != null
+                ? dto.getMonthlyProgressPct()
+                : dto.getActualProgress());
+        Double progressIncrementPct = clampPercent(dto.getProgressIncrementPct() != null
+                ? dto.getProgressIncrementPct()
+                : 0.0);
+
+        // feat : 금일 진척률과 월간 세부계획 누적 진척률을 포함하여 공사일보 정보 업데이트
+        dailyReport.updateReport(
+                monthlyPlan,
+                monthlyProgressPct,
+                dto.getTodayProgress(),
+                progressIncrementPct,
+                monthlyProgressPct,
+                dto.getActualWorkerCount(),
+                dto.getIssue(),
+                dto.getTodayWork(),
+                dto.getTomorrowPlan()
+        );
         DailyReport savedReport = dailyReportRepository.save(dailyReport);
 
-        // feat : 진척률 100% 미달 시 공정 기간 자동 연장
-        if (dto.getActualProgress() < 100.0) {
+        // feat : 월간 세부계획 누적 진척률 갱신
+        if (monthlyPlan != null) {
+            monthlyPlan.updateActualProgressPct(monthlyProgressPct);
+            workPlanRepository.save(monthlyPlan);
+        }
+
+        // feat : 금일 작업 진척률 100% 미달 시 해당 주간 계획 기간 자동 연장
+        double todayProgress = dto.getTodayProgress() == null ? 0.0 : dto.getTodayProgress();
+        if (todayProgress < 100.0) {
             WorkPlanExtension extension = workPlan.getExtension();
             if (extension == null) {
                 extension = WorkPlanExtension.builder().build();
@@ -121,6 +151,11 @@ public class DailyReportService {
         return savedReport.getIdx();
     }
 
+    private Double clampPercent(Double value) {
+        if (value == null) return 0.0;
+        return Math.max(0.0, Math.min(100.0, value));
+    }
+
     // feat : 특정 일자 공사일보 목록 조회 및 DTO 변환
     @Transactional(readOnly = true)
     public List<ReportDto.Res> getReportsByDate(LocalDate date) {
@@ -131,6 +166,9 @@ public class DailyReportService {
                         .process(r.getWorkPlan().getTrade() != null ? r.getWorkPlan().getTrade().getLabel() : "")
                         .actualProgress(r.getActualProgress())
                         .todayProgress(r.getTodayProgress())
+                        .monthlyWorkPlanId(r.getMonthlyWorkPlan() != null ? r.getMonthlyWorkPlan().getIdx() : null)
+                        .progressIncrementPct(r.getProgressIncrementPct())
+                        .monthlyProgressPct(r.getMonthlyProgressPct())
                         .actualWorkerCount(r.getActualWorkerCount())
                         .issue(r.getIssue())
                         .reportDate(r.getReportDate())

--- a/src/main/java/org/example/dndn/report/model/DailyReport.java
+++ b/src/main/java/org/example/dndn/report/model/DailyReport.java
@@ -21,9 +21,17 @@ public class DailyReport extends BaseEntity {
     @JoinColumn(name = "work_plan_idx")
     private WorkPlan workPlan; // feat : 연관된 주간 작업 계획 FK
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "monthly_work_plan_idx")
+    private WorkPlan monthlyWorkPlan; // feat : 누적 진척률을 반영할 부모 월간 세부계획 FK
+
     private Double actualProgress; // feat : 전체 누적 진척률
 
     private Double todayProgress; // feat : 금일 입력 진척률 (새로 추가된 컬럼)
+
+    private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영된 증가분
+
+    private Double monthlyProgressPct; // feat : 반영 후 월간 세부계획 누적 진척률
 
     private Integer actualWorkerCount; // feat : 금일 실제 투입 인원 수
 
@@ -39,9 +47,22 @@ public class DailyReport extends BaseEntity {
 
     // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
     // feat : 공사일보 정보 업데이트 메서드 (금일 진척률 반영)
-    public void updateReport(Double actualProgress, Double todayProgress, Integer actualWorkerCount, String issue, String todayWork, String tomorrowPlan) {
+    public void updateReport(
+            WorkPlan monthlyWorkPlan,
+            Double actualProgress,
+            Double todayProgress,
+            Double progressIncrementPct,
+            Double monthlyProgressPct,
+            Integer actualWorkerCount,
+            String issue,
+            String todayWork,
+            String tomorrowPlan
+    ) {
+        this.monthlyWorkPlan = monthlyWorkPlan;
         this.actualProgress = actualProgress;
         this.todayProgress = todayProgress;
+        this.progressIncrementPct = progressIncrementPct;
+        this.monthlyProgressPct = monthlyProgressPct;
         this.actualWorkerCount = actualWorkerCount;
         this.issue = issue;
         this.todayWork = todayWork;

--- a/src/main/java/org/example/dndn/report/model/ReportDto.java
+++ b/src/main/java/org/example/dndn/report/model/ReportDto.java
@@ -28,6 +28,10 @@ public class ReportDto {
 
         private Double todayProgress;       // feat : 금일 입력된 진척률 (예: 사용자가 입력한 90%)
 
+        private Long monthlyWorkPlanId;     // feat : 누적 진척률을 반영할 부모 월간 세부계획 ID
+        private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영되는 증가분
+        private Double monthlyProgressPct;   // feat : 반영 후 월간 세부계획 누적 진척률
+
         @NotNull(message = "actualWorkerCount is required")
         private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
 
@@ -59,6 +63,9 @@ public class ReportDto {
         private String process;             // feat : 공정명 (예: 전기 공정)
         private Double actualProgress;      // feat : 전체 누적 진척률
         private Double todayProgress;       // feat : 금일 입력된 진척률
+        private Long monthlyWorkPlanId;     // feat : 누적 진척률을 반영한 부모 월간 세부계획 ID
+        private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영된 증가분
+        private Double monthlyProgressPct;   // feat : 반영 후 월간 세부계획 누적 진척률
         private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
         private String issue;               // feat : 특이사항 및 이슈
         private LocalDate reportDate;       // feat : 공사일보 작성 일자

--- a/src/main/java/org/example/dndn/workplan/model/WorkPlanDto.java
+++ b/src/main/java/org/example/dndn/workplan/model/WorkPlanDto.java
@@ -7,6 +7,7 @@ import org.example.dndn.workplan.model.entity.WorkPlanExtension;
 import org.example.dndn.workplan.model.entity.WorkPlanWorker;
 import org.example.dndn.workplan.model.enums.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -225,6 +226,8 @@ public class WorkPlanDto {
         // ── 1단계 추가 ───────────────────────────────────────────────────────
         private Long tradeProcessId;
         private String tradeProcessName;
+        private Long parentWorkPlanId;
+        private String parentWorkPlanName;
         // ────────────────────────────────────────────────────────────────────
         private Long idx;
         private String name;
@@ -244,6 +247,7 @@ public class WorkPlanDto {
         private String manager;
         private String contact;
         private String note;
+        private BigDecimal actualProgressPct;
 
         public static workPlanRes from(WorkPlan entity) {
             String period = "";
@@ -260,6 +264,10 @@ public class WorkPlanDto {
                             ? entity.getTradeProcess().getIdx() : null)
                     .tradeProcessName(entity.getTradeProcess() != null
                             ? entity.getTradeProcess().getProcessName() : null)
+                    .parentWorkPlanId(entity.getParentWorkPlan() != null
+                            ? entity.getParentWorkPlan().getIdx() : null)
+                    .parentWorkPlanName(entity.getParentWorkPlan() != null
+                            ? entity.getParentWorkPlan().getName() : null)
                     // ────────────────────────────────────────────────────────
                     .idx(entity.getIdx())
                     .name(entity.getName())
@@ -279,6 +287,7 @@ public class WorkPlanDto {
                     .manager(entity.getManager())
                     .contact(entity.getContact())
                     .note(entity.getNote())
+                    .actualProgressPct(entity.getActualProgressPct())
                     .build();
         }
     }

--- a/src/main/java/org/example/dndn/workplan/model/entity/WorkPlan.java
+++ b/src/main/java/org/example/dndn/workplan/model/entity/WorkPlan.java
@@ -8,6 +8,7 @@ import org.example.dndn.workplan.model.enums.PlanStatus;
 import org.example.dndn.workplan.model.enums.PlanType;
 import org.example.dndn.workplan.model.enums.WorkTrade;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +61,11 @@ public class WorkPlan extends BaseEntity {
     private String partner; // 협력사명
     private String manager; // 담당자명
     private String contact; // 담당자 연락처
+    @Column(columnDefinition = "TEXT")
     private String note;    // 비고
+
+    @Column(name = "actual_progress_pct")
+    private BigDecimal actualProgressPct = BigDecimal.ZERO;
 
     @OneToMany(mappedBy = "workPlan", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -192,5 +197,12 @@ public class WorkPlan extends BaseEntity {
                 .filter(c -> c != null)
                 .mapToInt(Integer::intValue)
                 .sum();
+    }
+    public void updateActualProgressPct(Double actualProgressPct) {
+        double value = actualProgressPct == null
+                ? 0.0
+                : Math.max(0.0, Math.min(100.0, actualProgressPct));
+
+        this.actualProgressPct = java.math.BigDecimal.valueOf(value);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 공정 분석 페이지에서 사용할 백엔드 API 구현
- 공정별 진척률, 지연 위험도, 변경 요청 데이터를 조회할 수 있는 기능 추가
- 일정 변경 요청 등록 및 승인/반려 처리 기능 구현
- 공사일보 데이터를 기반으로 실제 진척률을 분석하는 로직 추가

## 상세 내용
- 공정 계획 데이터와 공사일보 데이터를 비교하여 계획 대비 실제 진척률 계산
- 지연 위험 공정을 조회할 수 있도록 분석 API 추가
- 공정 책임자가 일정 변경 요청을 등록할 수 있는 기능 구현
- 현장 총 책임자가 변경 요청을 승인 또는 반려할 수 있는 기능 구현
- 승인된 변경 요청은 공정 계획 일정에 반영되도록 처리
- 공정 분석 및 일정 변경 관련 Controller, Service, DTO, Repository 구성