### PR TITLE
[Feat] 권한 모델 정비 및 계전 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	implementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/org/example/dndn/auth/DataInitializer.java
+++ b/src/main/java/org/example/dndn/auth/DataInitializer.java
@@ -1,0 +1,49 @@
+package org.example.dndn.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.model.enums.UserRole;
+import org.example.dndn.auth.repository.SystemUserRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 애플리케이션 시작 시 ADMIN / HEADQUARTOR 계정을 최초 1회만 생성.
+ * 이미 loginId가 존재하면 건너뜀.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final SystemUserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        seedIfAbsent("admin",  "Admin1234!", "시스템관리자", UserRole.ADMIN,        null, null);
+        seedIfAbsent("hq",     "Hq1234567!", "본사",       UserRole.HEADQUARTOR,   null, null);
+    }
+
+    private void seedIfAbsent(String loginId, String rawPw, String name,
+                               UserRole role, String siteCode, String trade) {
+        if (userRepository.existsByLoginId(loginId)) {
+            return;
+        }
+        userRepository.save(SystemUser.builder()
+                .loginId(loginId)
+                .password(passwordEncoder.encode(rawPw))
+                .name(name)
+                .role(role)
+                .siteCode(siteCode)
+                .trade(trade)
+                .active(true)
+                .build());
+        log.info("[DataInitializer] 기본 계정 생성: loginId={}, role={}", loginId, role);
+    }
+}

--- a/src/main/java/org/example/dndn/auth/controller/AccountController.java
+++ b/src/main/java/org/example/dndn/auth/controller/AccountController.java
@@ -46,15 +46,6 @@ public class AccountController {
         return ResponseEntity.ok(BaseResponse.success(accountService.update(idx, req)));
     }
 
-    /** 비밀번호 변경. */
-    @PutMapping("/{idx}/password")
-    public ResponseEntity<BaseResponse<Void>> changePassword(
-            @PathVariable Long idx,
-            @Valid @RequestBody AccountDto.PasswordReq req) {
-        accountService.changePassword(idx, req);
-        return ResponseEntity.ok(BaseResponse.success(null));
-    }
-
     /** 계정 비활성화 (논리 삭제). */
     @DeleteMapping("/{idx}")
     public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long idx) {

--- a/src/main/java/org/example/dndn/auth/controller/AccountController.java
+++ b/src/main/java/org/example/dndn/auth/controller/AccountController.java
@@ -1,0 +1,64 @@
+package org.example.dndn.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AccountDto;
+import org.example.dndn.auth.service.AccountService;
+import org.example.dndn.common.model.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 계정 관리 — ADMIN 전용 (/admin/** 은 SecurityConfig 에서 ROLE_ADMIN 만 접근 허용).
+ */
+@RestController
+@RequestMapping("/admin/accounts")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    /** 전체 계정 목록 조회. */
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<AccountDto.Res>>> getAll() {
+        return ResponseEntity.ok(BaseResponse.success(accountService.getAll()));
+    }
+
+    /** 단일 계정 조회. */
+    @GetMapping("/{idx}")
+    public ResponseEntity<BaseResponse<AccountDto.Res>> getOne(@PathVariable Long idx) {
+        return ResponseEntity.ok(BaseResponse.success(accountService.getOne(idx)));
+    }
+
+    /** 계정 생성. */
+    @PostMapping
+    public ResponseEntity<BaseResponse<AccountDto.Res>> create(@Valid @RequestBody AccountDto.CreateReq req) {
+        return ResponseEntity.ok(BaseResponse.success(accountService.create(req)));
+    }
+
+    /** 계정 정보 수정 (이름/권한/현장/공종/활성화 여부). */
+    @PutMapping("/{idx}")
+    public ResponseEntity<BaseResponse<AccountDto.Res>> update(
+            @PathVariable Long idx,
+            @Valid @RequestBody AccountDto.UpdateReq req) {
+        return ResponseEntity.ok(BaseResponse.success(accountService.update(idx, req)));
+    }
+
+    /** 비밀번호 변경. */
+    @PutMapping("/{idx}/password")
+    public ResponseEntity<BaseResponse<Void>> changePassword(
+            @PathVariable Long idx,
+            @Valid @RequestBody AccountDto.PasswordReq req) {
+        accountService.changePassword(idx, req);
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+
+    /** 계정 비활성화 (논리 삭제). */
+    @DeleteMapping("/{idx}")
+    public ResponseEntity<BaseResponse<Void>> delete(@PathVariable Long idx) {
+        accountService.delete(idx);
+        return ResponseEntity.ok(BaseResponse.success(null));
+    }
+}

--- a/src/main/java/org/example/dndn/auth/controller/AccountRequestController.java
+++ b/src/main/java/org/example/dndn/auth/controller/AccountRequestController.java
@@ -1,0 +1,58 @@
+package org.example.dndn.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AccountRequestDto;
+import org.example.dndn.auth.model.enums.RequestStatus;
+import org.example.dndn.auth.service.AccountRequestService;
+import org.example.dndn.common.model.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountRequestController {
+
+    private final AccountRequestService requestService;
+
+    /** 계정 생성 요청 제출 — 인증된 사용자 누구나 가능. */
+    @PostMapping("/account-requests")
+    public ResponseEntity<BaseResponse<AccountRequestDto.Res>> create(
+            @AuthenticationPrincipal Long requesterIdx,
+            @Valid @RequestBody AccountRequestDto.CreateReq req) {
+        return ResponseEntity.ok(BaseResponse.success(requestService.create(requesterIdx, req)));
+    }
+
+    /** [ADMIN] 요청 목록 조회. status 파라미터로 필터링 가능 (PENDING/APPROVED/REJECTED). */
+    @GetMapping("/admin/account-requests")
+    public ResponseEntity<BaseResponse<List<AccountRequestDto.Res>>> getAll(
+            @RequestParam(required = false) RequestStatus status) {
+        return ResponseEntity.ok(BaseResponse.success(requestService.getAll(status)));
+    }
+
+    /** [ADMIN] 요청 단건 조회. */
+    @GetMapping("/admin/account-requests/{idx}")
+    public ResponseEntity<BaseResponse<AccountRequestDto.Res>> getOne(@PathVariable Long idx) {
+        return ResponseEntity.ok(BaseResponse.success(requestService.getOne(idx)));
+    }
+
+    /** [ADMIN] 요청 승인 — 초기 비밀번호와 함께 계정 자동 생성. */
+    @PutMapping("/admin/account-requests/{idx}/approve")
+    public ResponseEntity<BaseResponse<AccountRequestDto.Res>> approve(
+            @PathVariable Long idx,
+            @Valid @RequestBody AccountRequestDto.ApproveReq req) {
+        return ResponseEntity.ok(BaseResponse.success(requestService.approve(idx, req)));
+    }
+
+    /** [ADMIN] 요청 거절. */
+    @PutMapping("/admin/account-requests/{idx}/reject")
+    public ResponseEntity<BaseResponse<AccountRequestDto.Res>> reject(
+            @PathVariable Long idx,
+            @RequestBody(required = false) AccountRequestDto.RejectReq req) {
+        return ResponseEntity.ok(BaseResponse.success(
+                requestService.reject(idx, req != null ? req : new AccountRequestDto.RejectReq())));
+    }
+}

--- a/src/main/java/org/example/dndn/auth/controller/AuthController.java
+++ b/src/main/java/org/example/dndn/auth/controller/AuthController.java
@@ -19,4 +19,10 @@ public class AuthController {
     public ResponseEntity<BaseResponse<AuthDto.LoginRes>> login(@Valid @RequestBody AuthDto.LoginReq req) {
         return ResponseEntity.ok(BaseResponse.success(authService.login(req)));
     }
+
+    @PutMapping("/password")
+    public ResponseEntity<?> changePassword(@Valid @RequestBody AuthDto.ChangePasswordReq req) {
+        authService.changePassword(req);
+        return ResponseEntity.ok(BaseResponse.success("비밀번호가 변경되었습니다."));
+    }
 }

--- a/src/main/java/org/example/dndn/auth/controller/AuthController.java
+++ b/src/main/java/org/example/dndn/auth/controller/AuthController.java
@@ -1,0 +1,22 @@
+package org.example.dndn.auth.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AuthDto;
+import org.example.dndn.auth.service.AuthService;
+import org.example.dndn.common.model.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<BaseResponse<AuthDto.LoginRes>> login(@Valid @RequestBody AuthDto.LoginReq req) {
+        return ResponseEntity.ok(BaseResponse.success(authService.login(req)));
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/dto/AccountDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AccountDto.java
@@ -34,6 +34,12 @@ public class AccountDto {
 
         @Size(max = 80)
         private String trade;
+
+        @Size(max = 20)
+        private String phone;
+
+        @Size(max = 100)
+        private String email;
     }
 
     @Getter
@@ -53,13 +59,12 @@ public class AccountDto {
 
         @NotNull
         private Boolean active;
-    }
 
-    @Getter
-    public static class PasswordReq {
-        @NotBlank
-        @Size(min = 8, max = 100)
-        private String newPassword;
+        @Size(max = 20)
+        private String phone;
+
+        @Size(max = 100)
+        private String email;
     }
 
     @Getter
@@ -71,6 +76,8 @@ public class AccountDto {
         private UserRole role;
         private String siteCode;
         private String trade;
+        private String phone;
+        private String email;
         private boolean active;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
@@ -83,6 +90,8 @@ public class AccountDto {
                     .role(u.getRole())
                     .siteCode(u.getSiteCode())
                     .trade(u.getTrade())
+                    .phone(u.getPhone())
+                    .email(u.getEmail())
                     .active(u.isActive())
                     .createdAt(u.getCreatedAt())
                     .updatedAt(u.getUpdatedAt())

--- a/src/main/java/org/example/dndn/auth/model/dto/AccountDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AccountDto.java
@@ -1,0 +1,92 @@
+package org.example.dndn.auth.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.model.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+public class AccountDto {
+
+    @Getter
+    public static class CreateReq {
+        @NotBlank
+        @Size(max = 50)
+        private String loginId;
+
+        @NotBlank
+        @Size(min = 8, max = 100)
+        private String password;
+
+        @NotBlank
+        @Size(max = 50)
+        private String name;
+
+        @NotNull
+        private UserRole role;
+
+        @Size(max = 50)
+        private String siteCode;
+
+        @Size(max = 80)
+        private String trade;
+    }
+
+    @Getter
+    public static class UpdateReq {
+        @NotBlank
+        @Size(max = 50)
+        private String name;
+
+        @NotNull
+        private UserRole role;
+
+        @Size(max = 50)
+        private String siteCode;
+
+        @Size(max = 80)
+        private String trade;
+
+        @NotNull
+        private Boolean active;
+    }
+
+    @Getter
+    public static class PasswordReq {
+        @NotBlank
+        @Size(min = 8, max = 100)
+        private String newPassword;
+    }
+
+    @Getter
+    @Builder
+    public static class Res {
+        private Long idx;
+        private String loginId;
+        private String name;
+        private UserRole role;
+        private String siteCode;
+        private String trade;
+        private boolean active;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Res from(SystemUser u) {
+            return Res.builder()
+                    .idx(u.getIdx())
+                    .loginId(u.getLoginId())
+                    .name(u.getName())
+                    .role(u.getRole())
+                    .siteCode(u.getSiteCode())
+                    .trade(u.getTrade())
+                    .active(u.isActive())
+                    .createdAt(u.getCreatedAt())
+                    .updatedAt(u.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/dto/AccountRequestDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AccountRequestDto.java
@@ -1,0 +1,85 @@
+package org.example.dndn.auth.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.dndn.auth.model.entity.AccountRequest;
+import org.example.dndn.auth.model.enums.RequestStatus;
+import org.example.dndn.auth.model.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+public class AccountRequestDto {
+
+    @Getter
+    public static class CreateReq {
+        @NotBlank
+        @Size(max = 50)
+        private String requestedName;
+
+        @NotBlank
+        @Size(max = 50)
+        private String requestedLoginId;
+
+        @NotNull
+        private UserRole requestedRole;
+
+        @Size(max = 50)
+        private String siteCode;
+
+        @Size(max = 80)
+        private String trade;
+    }
+
+    /** 승인 시 초기 비밀번호를 관리자가 지정. */
+    @Getter
+    public static class ApproveReq {
+        @NotBlank
+        @Size(min = 8, max = 100)
+        private String initialPassword;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class RejectReq {
+        @Size(max = 300)
+        private String note;
+    }
+
+    @Getter
+    @Builder
+    public static class Res {
+        private Long idx;
+        private Long requesterIdx;
+        private String requesterName;
+        private String requestedName;
+        private String requestedLoginId;
+        private UserRole requestedRole;
+        private String siteCode;
+        private String trade;
+        private RequestStatus status;
+        private String note;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Res from(AccountRequest r) {
+            return Res.builder()
+                    .idx(r.getIdx())
+                    .requesterIdx(r.getRequester().getIdx())
+                    .requesterName(r.getRequester().getName())
+                    .requestedName(r.getRequestedName())
+                    .requestedLoginId(r.getRequestedLoginId())
+                    .requestedRole(r.getRequestedRole())
+                    .siteCode(r.getSiteCode())
+                    .trade(r.getTrade())
+                    .status(r.getStatus())
+                    .note(r.getNote())
+                    .createdAt(r.getCreatedAt())
+                    .updatedAt(r.getUpdatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/dto/AccountRequestDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AccountRequestDto.java
@@ -34,10 +34,10 @@ public class AccountRequestDto {
         private String trade;
     }
 
-    /** 승인 시 초기 비밀번호를 관리자가 지정. */
+    /** 승인 시 초기 비밀번호를 관리자가 지정. 미입력 시 임시 비밀번호 자동 생성. */
     @Getter
+    @NoArgsConstructor
     public static class ApproveReq {
-        @NotBlank
         @Size(min = 8, max = 100)
         private String initialPassword;
     }
@@ -55,9 +55,13 @@ public class AccountRequestDto {
         private Long idx;
         private Long requesterIdx;
         private String requesterName;
+        /** 프론트 호환 — requesterName 과 동일 값. */
+        private String name;
         private String requestedName;
         private String requestedLoginId;
         private UserRole requestedRole;
+        /** 프론트 호환 — 요청자(requester) 의 권한. */
+        private UserRole role;
         private String siteCode;
         private String trade;
         private RequestStatus status;
@@ -70,9 +74,11 @@ public class AccountRequestDto {
                     .idx(r.getIdx())
                     .requesterIdx(r.getRequester().getIdx())
                     .requesterName(r.getRequester().getName())
+                    .name(r.getRequester().getName())
                     .requestedName(r.getRequestedName())
                     .requestedLoginId(r.getRequestedLoginId())
                     .requestedRole(r.getRequestedRole())
+                    .role(r.getRequester().getRole())
                     .siteCode(r.getSiteCode())
                     .trade(r.getTrade())
                     .status(r.getStatus())

--- a/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
@@ -1,8 +1,10 @@
 package org.example.dndn.auth.model.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.example.dndn.auth.model.enums.UserRole;
 
 public class AuthDto {
@@ -13,6 +15,17 @@ public class AuthDto {
         private String loginId;
         @NotBlank
         private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ChangePasswordReq {
+        @NotBlank
+        private String currentPassword;
+
+        @NotBlank
+        @Size(min = 8, max = 100)
+        private String newPassword;
     }
 
     @Getter

--- a/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
@@ -1,0 +1,28 @@
+package org.example.dndn.auth.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Builder;
+import org.example.dndn.auth.model.enums.UserRole;
+
+public class AuthDto {
+
+    @Getter
+    public static class LoginReq {
+        @NotBlank
+        private String loginId;
+        @NotBlank
+        private String password;
+    }
+
+    @Getter
+    @Builder
+    public static class LoginRes {
+        private String accessToken;
+        private Long userIdx;
+        private String name;
+        private UserRole role;
+        private String siteCode;
+        private String trade;
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/entity/AccountRequest.java
+++ b/src/main/java/org/example/dndn/auth/model/entity/AccountRequest.java
@@ -1,0 +1,58 @@
+package org.example.dndn.auth.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.auth.model.enums.RequestStatus;
+import org.example.dndn.auth.model.enums.UserRole;
+import org.example.dndn.common.model.BaseEntity;
+
+@Entity
+@Table(name = "account_request")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class AccountRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    /** 요청을 보낸 계정. 본사/현장 총 책임자/공종 책임자가 요청. */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "requester_idx", nullable = false)
+    private SystemUser requester;
+
+    @Column(nullable = false, length = 50)
+    private String requestedName;
+
+    @Column(nullable = false, length = 50)
+    private String requestedLoginId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private UserRole requestedRole;
+
+    @Column(length = 50)
+    private String siteCode;
+
+    @Column(length = 80)
+    private String trade;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    private RequestStatus status;
+
+    /** 거절 시 사유. */
+    @Column(length = 300)
+    private String note;
+
+    public void approve() {
+        this.status = RequestStatus.APPROVED;
+    }
+
+    public void reject(String note) {
+        this.status = RequestStatus.REJECTED;
+        this.note = note;
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/entity/SystemUser.java
+++ b/src/main/java/org/example/dndn/auth/model/entity/SystemUser.java
@@ -6,7 +6,7 @@ import org.example.dndn.auth.model.enums.UserRole;
 import org.example.dndn.common.model.BaseEntity;
 
 @Entity
-@Table(name = "system_user")
+@Table(name = "account")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -38,15 +38,23 @@ public class SystemUser extends BaseEntity {
     @Column(length = 80)
     private String trade;
 
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 100)
+    private String email;
+
     @Column(nullable = false)
     private boolean active;
 
-    public void update(String name, UserRole role, String siteCode, String trade, boolean active) {
+    public void update(String name, UserRole role, String siteCode, String trade, boolean active, String phone, String email) {
         this.name = name;
         this.role = role;
         this.siteCode = siteCode;
         this.trade = trade;
         this.active = active;
+        this.phone = phone;
+        this.email = email;
     }
 
     public void changePassword(String encodedPassword) {

--- a/src/main/java/org/example/dndn/auth/model/entity/SystemUser.java
+++ b/src/main/java/org/example/dndn/auth/model/entity/SystemUser.java
@@ -1,0 +1,59 @@
+package org.example.dndn.auth.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.auth.model.enums.UserRole;
+import org.example.dndn.common.model.BaseEntity;
+
+@Entity
+@Table(name = "system_user")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class SystemUser extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String loginId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 25)
+    private UserRole role;
+
+    /** SITE_DIRECTOR 이상 공종별 계정에 해당하는 현장 코드. ADMIN/HEADQUARTOR 는 null. */
+    @Column(length = 50)
+    private String siteCode;
+
+    /** SECTION_LEADER / SECTION_SUPERVISOR 의 공종명 (예: 토목, 골조). 그 외 null. */
+    @Column(length = 80)
+    private String trade;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    public void update(String name, UserRole role, String siteCode, String trade, boolean active) {
+        this.name = name;
+        this.role = role;
+        this.siteCode = siteCode;
+        this.trade = trade;
+        this.active = active;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+}

--- a/src/main/java/org/example/dndn/auth/model/enums/RequestStatus.java
+++ b/src/main/java/org/example/dndn/auth/model/enums/RequestStatus.java
@@ -1,0 +1,7 @@
+package org.example.dndn.auth.model.enums;
+
+public enum RequestStatus {
+    PENDING,   // 검토 대기
+    APPROVED,  // 승인 완료 (계정 생성됨)
+    REJECTED   // 거절
+}

--- a/src/main/java/org/example/dndn/auth/model/enums/UserRole.java
+++ b/src/main/java/org/example/dndn/auth/model/enums/UserRole.java
@@ -1,0 +1,9 @@
+package org.example.dndn.auth.model.enums;
+
+public enum UserRole {
+    ADMIN,              // 시스템 관리자
+    HEADQUARTOR,        // 본사
+    SITE_DIRECTOR,      // 현장 총 책임자
+    SECTION_LEADER,     // 공종별 책임자
+    SECTION_SUPERVISOR  // 공종별 현장 관리자
+}

--- a/src/main/java/org/example/dndn/auth/model/enums/UserRole.java
+++ b/src/main/java/org/example/dndn/auth/model/enums/UserRole.java
@@ -1,9 +1,10 @@
 package org.example.dndn.auth.model.enums;
 
 public enum UserRole {
-    ADMIN,              // 시스템 관리자
-    HEADQUARTOR,        // 본사
-    SITE_DIRECTOR,      // 현장 총 책임자
-    SECTION_LEADER,     // 공종별 책임자
-    SECTION_SUPERVISOR  // 공종별 현장 관리자
+    ADMIN,                    // 시스템 관리자
+    HEADQUARTOR,              // 본사
+    SITE_MANAGER,             // 현장 관리자
+    SITE_DIRECTOR,            // 현장 총 책임자
+    SECTION_LEADER,           // 공종별 책임자
+    SECTION_SUPERVISOR        // 공종별 현장 관리자
 }

--- a/src/main/java/org/example/dndn/auth/repository/AccountRequestRepository.java
+++ b/src/main/java/org/example/dndn/auth/repository/AccountRequestRepository.java
@@ -1,0 +1,14 @@
+package org.example.dndn.auth.repository;
+
+import org.example.dndn.auth.model.entity.AccountRequest;
+import org.example.dndn.auth.model.enums.RequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AccountRequestRepository extends JpaRepository<AccountRequest, Long> {
+
+    List<AccountRequest> findAllByOrderByCreatedAtDesc();
+
+    List<AccountRequest> findAllByStatusOrderByCreatedAtDesc(RequestStatus status);
+}

--- a/src/main/java/org/example/dndn/auth/repository/SystemUserRepository.java
+++ b/src/main/java/org/example/dndn/auth/repository/SystemUserRepository.java
@@ -1,0 +1,13 @@
+package org.example.dndn.auth.repository;
+
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SystemUserRepository extends JpaRepository<SystemUser, Long> {
+
+    Optional<SystemUser> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/org/example/dndn/auth/security/JwtFilter.java
+++ b/src/main/java/org/example/dndn/auth/security/JwtFilter.java
@@ -1,0 +1,42 @@
+package org.example.dndn.auth.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            try {
+                Claims claims = jwtProvider.parse(header.substring(7));
+                Long idx = claims.get("idx", Long.class);
+                String role = claims.get("role", String.class);
+                var auth = new UsernamePasswordAuthenticationToken(
+                        idx, null, List.of(new SimpleGrantedAuthority("ROLE_" + role)));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (Exception ignored) {
+                // 유효하지 않은 토큰은 인증 없이 통과 — 이후 접근 제어에서 거절됨
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/example/dndn/auth/security/JwtProvider.java
+++ b/src/main/java/org/example/dndn/auth/security/JwtProvider.java
@@ -1,0 +1,45 @@
+package org.example.dndn.auth.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.example.dndn.auth.model.enums.UserRole;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey key;
+    private final long expirationMs;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration-ms:86400000}") long expirationMs) {
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        this.expirationMs = expirationMs;
+    }
+
+    public String generate(Long userIdx, String loginId, UserRole role) {
+        return Jwts.builder()
+                .subject(loginId)
+                .claim("idx", userIdx)
+                .claim("role", role.name())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
@@ -15,6 +15,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.http.HttpMethod;
+
 import java.util.List;
 
 @Configuration
@@ -31,6 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.PUT, "/auth/password").authenticated()
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/account-requests").authenticated()

--- a/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
@@ -1,0 +1,59 @@
+package org.example.dndn.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/account-requests").authenticated()
+                        .anyRequest().permitAll()   // 기존 엔드포인트는 현행 유지 (추후 역할별 제한 추가)
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/org/example/dndn/auth/service/AccountRequestService.java
+++ b/src/main/java/org/example/dndn/auth/service/AccountRequestService.java
@@ -2,6 +2,7 @@ package org.example.dndn.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.dndn.auth.model.dto.AccountRequestDto;
+import java.util.UUID;
 import org.example.dndn.auth.model.entity.AccountRequest;
 import org.example.dndn.auth.model.entity.SystemUser;
 import org.example.dndn.auth.model.enums.RequestStatus;
@@ -66,9 +67,13 @@ public class AccountRequestService {
             throw new BaseException(FAIL);
         }
 
+        String rawPassword = (req.getInitialPassword() != null && req.getInitialPassword().length() >= 8)
+                ? req.getInitialPassword()
+                : UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+
         userRepository.save(SystemUser.builder()
                 .loginId(request.getRequestedLoginId())
-                .password(passwordEncoder.encode(req.getInitialPassword()))
+                .password(passwordEncoder.encode(rawPassword))
                 .name(request.getRequestedName())
                 .role(request.getRequestedRole())
                 .siteCode(request.getSiteCode())

--- a/src/main/java/org/example/dndn/auth/service/AccountRequestService.java
+++ b/src/main/java/org/example/dndn/auth/service/AccountRequestService.java
@@ -1,0 +1,98 @@
+package org.example.dndn.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AccountRequestDto;
+import org.example.dndn.auth.model.entity.AccountRequest;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.model.enums.RequestStatus;
+import org.example.dndn.auth.repository.AccountRequestRepository;
+import org.example.dndn.auth.repository.SystemUserRepository;
+import org.example.dndn.common.exception.BaseException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.dndn.common.model.BaseResponseStatus.FAIL;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountRequestService {
+
+    private final AccountRequestRepository requestRepository;
+    private final SystemUserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    /** 인증된 사용자(requesterIdx)가 계정 생성을 요청. */
+    @Transactional
+    public AccountRequestDto.Res create(Long requesterIdx, AccountRequestDto.CreateReq req) {
+        SystemUser requester = userRepository.findById(requesterIdx)
+                .orElseThrow(() -> new BaseException(FAIL));
+
+        AccountRequest saved = requestRepository.save(AccountRequest.builder()
+                .requester(requester)
+                .requestedName(req.getRequestedName())
+                .requestedLoginId(req.getRequestedLoginId())
+                .requestedRole(req.getRequestedRole())
+                .siteCode(req.getSiteCode())
+                .trade(req.getTrade())
+                .status(RequestStatus.PENDING)
+                .build());
+        return AccountRequestDto.Res.from(saved);
+    }
+
+    public List<AccountRequestDto.Res> getAll(RequestStatus status) {
+        List<AccountRequest> list = (status == null)
+                ? requestRepository.findAllByOrderByCreatedAtDesc()
+                : requestRepository.findAllByStatusOrderByCreatedAtDesc(status);
+        return list.stream().map(AccountRequestDto.Res::from).collect(Collectors.toList());
+    }
+
+    public AccountRequestDto.Res getOne(Long idx) {
+        return AccountRequestDto.Res.from(findById(idx));
+    }
+
+    /** 승인: 요청 상태를 APPROVED로 변경하고 계정을 자동 생성. */
+    @Transactional
+    public AccountRequestDto.Res approve(Long idx, AccountRequestDto.ApproveReq req) {
+        AccountRequest request = findById(idx);
+        if (request.getStatus() != RequestStatus.PENDING) {
+            throw new BaseException(FAIL);
+        }
+        if (userRepository.existsByLoginId(request.getRequestedLoginId())) {
+            throw new BaseException(FAIL);
+        }
+
+        userRepository.save(SystemUser.builder()
+                .loginId(request.getRequestedLoginId())
+                .password(passwordEncoder.encode(req.getInitialPassword()))
+                .name(request.getRequestedName())
+                .role(request.getRequestedRole())
+                .siteCode(request.getSiteCode())
+                .trade(request.getTrade())
+                .active(true)
+                .build());
+
+        request.approve();
+        return AccountRequestDto.Res.from(request);
+    }
+
+    /** 거절: 요청 상태를 REJECTED로 변경. */
+    @Transactional
+    public AccountRequestDto.Res reject(Long idx, AccountRequestDto.RejectReq req) {
+        AccountRequest request = findById(idx);
+        if (request.getStatus() != RequestStatus.PENDING) {
+            throw new BaseException(FAIL);
+        }
+        request.reject(req.getNote());
+        return AccountRequestDto.Res.from(request);
+    }
+
+    private AccountRequest findById(Long idx) {
+        return requestRepository.findById(idx)
+                .orElseThrow(() -> new BaseException(FAIL));
+    }
+}

--- a/src/main/java/org/example/dndn/auth/service/AccountService.java
+++ b/src/main/java/org/example/dndn/auth/service/AccountService.java
@@ -1,0 +1,76 @@
+package org.example.dndn.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AccountDto;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.repository.SystemUserRepository;
+import org.example.dndn.common.exception.BaseException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.example.dndn.common.model.BaseResponseStatus.FAIL;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AccountService {
+
+    private final SystemUserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public List<AccountDto.Res> getAll() {
+        return userRepository.findAll().stream()
+                .map(AccountDto.Res::from)
+                .collect(Collectors.toList());
+    }
+
+    public AccountDto.Res getOne(Long idx) {
+        return AccountDto.Res.from(findById(idx));
+    }
+
+    @Transactional
+    public AccountDto.Res create(AccountDto.CreateReq req) {
+        if (userRepository.existsByLoginId(req.getLoginId())) {
+            throw new BaseException(FAIL);
+        }
+        SystemUser saved = userRepository.save(SystemUser.builder()
+                .loginId(req.getLoginId())
+                .password(passwordEncoder.encode(req.getPassword()))
+                .name(req.getName())
+                .role(req.getRole())
+                .siteCode(req.getSiteCode())
+                .trade(req.getTrade())
+                .active(true)
+                .build());
+        return AccountDto.Res.from(saved);
+    }
+
+    @Transactional
+    public AccountDto.Res update(Long idx, AccountDto.UpdateReq req) {
+        SystemUser user = findById(idx);
+        user.update(req.getName(), req.getRole(), req.getSiteCode(), req.getTrade(), req.getActive());
+        return AccountDto.Res.from(user);
+    }
+
+    @Transactional
+    public void changePassword(Long idx, AccountDto.PasswordReq req) {
+        SystemUser user = findById(idx);
+        user.changePassword(passwordEncoder.encode(req.getNewPassword()));
+    }
+
+    /** 논리 삭제 — 계정 비활성화. */
+    @Transactional
+    public void delete(Long idx) {
+        SystemUser user = findById(idx);
+        user.deactivate();
+    }
+
+    private SystemUser findById(Long idx) {
+        return userRepository.findById(idx)
+                .orElseThrow(() -> new BaseException(FAIL));
+    }
+}

--- a/src/main/java/org/example/dndn/auth/service/AccountService.java
+++ b/src/main/java/org/example/dndn/auth/service/AccountService.java
@@ -44,6 +44,8 @@ public class AccountService {
                 .role(req.getRole())
                 .siteCode(req.getSiteCode())
                 .trade(req.getTrade())
+                .phone(req.getPhone())
+                .email(req.getEmail())
                 .active(true)
                 .build());
         return AccountDto.Res.from(saved);
@@ -52,14 +54,8 @@ public class AccountService {
     @Transactional
     public AccountDto.Res update(Long idx, AccountDto.UpdateReq req) {
         SystemUser user = findById(idx);
-        user.update(req.getName(), req.getRole(), req.getSiteCode(), req.getTrade(), req.getActive());
+        user.update(req.getName(), req.getRole(), req.getSiteCode(), req.getTrade(), req.getActive(), req.getPhone(), req.getEmail());
         return AccountDto.Res.from(user);
-    }
-
-    @Transactional
-    public void changePassword(Long idx, AccountDto.PasswordReq req) {
-        SystemUser user = findById(idx);
-        user.changePassword(passwordEncoder.encode(req.getNewPassword()));
     }
 
     /** 논리 삭제 — 계정 비활성화. */

--- a/src/main/java/org/example/dndn/auth/service/AuthService.java
+++ b/src/main/java/org/example/dndn/auth/service/AuthService.java
@@ -6,11 +6,13 @@ import org.example.dndn.auth.model.entity.SystemUser;
 import org.example.dndn.auth.repository.SystemUserRepository;
 import org.example.dndn.auth.security.JwtProvider;
 import org.example.dndn.common.exception.BaseException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.example.dndn.common.model.BaseResponseStatus.FAIL;
+import static org.example.dndn.common.model.BaseResponseStatus.LOGIN_INVALID_USERINFO;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,27 @@ public class AuthService {
     private final SystemUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+
+    @Transactional
+    public void changePassword(AuthDto.ChangePasswordReq req) {
+        Long userIdx = getAuthenticatedIdx();
+        SystemUser user = userRepository.findById(userIdx)
+                .orElseThrow(() -> new BaseException(FAIL));
+
+        if (!passwordEncoder.matches(req.getCurrentPassword(), user.getPassword())) {
+            throw new BaseException(LOGIN_INVALID_USERINFO);
+        }
+
+        user.changePassword(passwordEncoder.encode(req.getNewPassword()));
+    }
+
+    private Long getAuthenticatedIdx() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || !(auth.getPrincipal() instanceof Long)) {
+            throw new BaseException(FAIL);
+        }
+        return (Long) auth.getPrincipal();
+    }
 
     public AuthDto.LoginRes login(AuthDto.LoginReq req) {
         SystemUser user = userRepository.findByLoginId(req.getLoginId())

--- a/src/main/java/org/example/dndn/auth/service/AuthService.java
+++ b/src/main/java/org/example/dndn/auth/service/AuthService.java
@@ -1,0 +1,45 @@
+package org.example.dndn.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.dto.AuthDto;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.repository.SystemUserRepository;
+import org.example.dndn.auth.security.JwtProvider;
+import org.example.dndn.common.exception.BaseException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.example.dndn.common.model.BaseResponseStatus.FAIL;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final SystemUserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    public AuthDto.LoginRes login(AuthDto.LoginReq req) {
+        SystemUser user = userRepository.findByLoginId(req.getLoginId())
+                .orElseThrow(() -> new BaseException(FAIL));
+
+        if (!user.isActive()) {
+            throw new BaseException(FAIL);
+        }
+        if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
+            throw new BaseException(FAIL);
+        }
+
+        String token = jwtProvider.generate(user.getIdx(), user.getLoginId(), user.getRole());
+        return AuthDto.LoginRes.builder()
+                .accessToken(token)
+                .userIdx(user.getIdx())
+                .name(user.getName())
+                .role(user.getRole())
+                .siteCode(user.getSiteCode())
+                .trade(user.getTrade())
+                .build();
+    }
+}

--- a/src/main/java/org/example/dndn/project/controller/TradeProcessController.java
+++ b/src/main/java/org/example/dndn/project/controller/TradeProcessController.java
@@ -37,6 +37,17 @@ public class TradeProcessController {
                 tradeProcessService.listByProject(projectId, tradeName)));
     }
 
+    /**
+     * 계정 생성 공종 드롭다운 전용.
+     * GET /trade-process/milestone-trades?projectId={projectId}
+     * isMilestone=true 이고 '준공','착공' 제외한 공종명 목록(List<String>) 반환.
+     */
+    @GetMapping("/milestone-trades")
+    public ResponseEntity<?> getMilestoneTradeNames(@RequestParam("projectId") Long projectId) {
+        return ResponseEntity.ok(BaseResponse.success(
+                tradeProcessService.listMilestoneTradeNamesByProject(projectId)));
+    }
+
     // 공정표별 공정 목록
     // GET /trade-process/by-schedule/1
     @GetMapping("/by-schedule/{scheduleId}")

--- a/src/main/java/org/example/dndn/project/repository/TradeProcessRepository.java
+++ b/src/main/java/org/example/dndn/project/repository/TradeProcessRepository.java
@@ -2,6 +2,8 @@ package org.example.dndn.project.repository;
 
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +14,16 @@ public interface TradeProcessRepository extends JpaRepository<TradeProcess, Long
     List<TradeProcess> findAllByMasterSchedule_Project_Idx(Long projectId);
 
     List<TradeProcess> findAllByMasterSchedule_Project_IdxAndTradeName(Long projectId, String tradeName);
+
+    /**
+     * 현장(project) 에 연결된 master_schedule 의 trade_process 중
+     * isMilestone = true 이고 '준공', '착공' 을 제외한 공종명(tradeName) 을 중복 없이 반환.
+     * 계정 생성 시 공종 드롭다운 목록 전용.
+     */
+    @Query("SELECT DISTINCT t.tradeName FROM TradeProcess t " +
+           "WHERE t.masterSchedule.project.idx = :projectId " +
+           "AND t.isMilestone = true " +
+           "AND t.tradeName NOT IN ('준공', '착공') " +
+           "ORDER BY t.tradeName")
+    List<String> findMilestoneTradeNamesByProjectId(@Param("projectId") Long projectId);
 }

--- a/src/main/java/org/example/dndn/project/service/TradeProcessService.java
+++ b/src/main/java/org/example/dndn/project/service/TradeProcessService.java
@@ -58,6 +58,15 @@ public class TradeProcessService {
                 .toList();
     }
 
+    /**
+     * 계정 생성 시 공종 드롭다운 전용.
+     * 현장(projectId) 기준으로 master_schedule → trade_process 를 조회하여
+     * isMilestone = true 이고 '준공', '착공' 을 제외한 공종명 목록을 반환.
+     */
+    public List<String> listMilestoneTradeNamesByProject(Long projectId) {
+        return tradeProcessRepository.findMilestoneTradeNamesByProjectId(projectId);
+    }
+
     @Transactional
     public void update(Long tpId, TradeProcessDto.Req dto) {
         findTradeProcess(tpId).update(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -47,3 +47,7 @@ weather:
     enabled: true
     cron: "0 0/30 * * * *"
     warmup-on-startup: true
+
+jwt:
+  secret: ${JWT_SECRET}
+  expiration-ms: ${JWT_EXPIRATION_MS:86400000}


### PR DESCRIPTION
## Summary
  - [AUTH_001] UserRole 권한 모델 정비 및 현장 관리자 역할 분리 (`SITE_MANAGER` rename, `account` 테이블 명칭 통일)
  - [AUTH_002] 계정 생성 시 현장 선택 기반 공종 드롭다운 자동 연동 (`GET /trade-process/milestone-trades`)
  - [AUTH_003] 본인 비밀번호 변경 기능 구현 (`PUT /auth/password`, 현재 비밀번호 검증 포함)
  - [AUTH_004] 계정 현황 페이지 UI 구조 개선 (현장 컬럼 제거, 현장 관리자 본사 직영 탭 편입

Closed #273 
Closed #274  
Closed #275 
Closed #276 