### PR TITLE
[Feat] 지연 분석 및 일정 변경 반영 백엔드 기능 추가

### DIFF
--- a/src/main/java/org/example/dndn/ai/AiScheduleRecommendationController.java
+++ b/src/main/java/org/example/dndn/ai/AiScheduleRecommendationController.java
@@ -1,0 +1,46 @@
+package org.example.dndn.ai;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.ai.model.AiScheduleRecommendationDto;
+import org.example.dndn.common.model.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/ai/schedule-recommendations")
+@RequiredArgsConstructor
+public class AiScheduleRecommendationController {
+
+    private final AiScheduleRecommendationService recommendationService;
+
+    @PostMapping
+    public ResponseEntity<?> create(@RequestBody AiScheduleRecommendationDto.CreateReq req) {
+        return ResponseEntity.ok(BaseResponse.success(recommendationService.create(req)));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> list(@RequestParam("projectId") Long projectId) {
+        return ResponseEntity.ok(BaseResponse.success(recommendationService.list(projectId)));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> get(@PathVariable Long id) {
+        return ResponseEntity.ok(BaseResponse.success(recommendationService.get(id)));
+    }
+
+    @PostMapping("/{id}/complete")
+    public ResponseEntity<?> complete(
+            @PathVariable Long id,
+            @RequestBody AiScheduleRecommendationDto.CompleteReq req
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(recommendationService.complete(id, req)));
+    }
+
+    @PostMapping("/{id}/fail")
+    public ResponseEntity<?> fail(
+            @PathVariable Long id,
+            @RequestBody AiScheduleRecommendationDto.FailReq req
+    ) {
+        return ResponseEntity.ok(BaseResponse.success(recommendationService.fail(id, req)));
+    }
+}

--- a/src/main/java/org/example/dndn/ai/AiScheduleRecommendationRepository.java
+++ b/src/main/java/org/example/dndn/ai/AiScheduleRecommendationRepository.java
@@ -1,0 +1,10 @@
+package org.example.dndn.ai;
+
+import org.example.dndn.ai.model.AiScheduleRecommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AiScheduleRecommendationRepository extends JpaRepository<AiScheduleRecommendation, Long> {
+    List<AiScheduleRecommendation> findAllByProject_IdxOrderByCreatedAtDesc(Long projectId);
+}

--- a/src/main/java/org/example/dndn/ai/AiScheduleRecommendationService.java
+++ b/src/main/java/org/example/dndn/ai/AiScheduleRecommendationService.java
@@ -1,0 +1,341 @@
+package org.example.dndn.ai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.ai.model.AiScheduleRecommendation;
+import org.example.dndn.ai.model.AiScheduleRecommendationDto;
+import org.example.dndn.analysis.AnalysisService;
+import org.example.dndn.analysis.model.AnalysisDto;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.project.repository.ProjectRepository;
+import org.example.dndn.workplan.WorkPlanRepository;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.example.dndn.workplan.model.enums.PlanType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiScheduleRecommendationService {
+
+    private static final Pattern WORK_TIME_PATTERN =
+            Pattern.compile("\\d{1,2}:\\d{2}\\s*(?:~|\\uFF5E)\\s*\\d{1,2}:\\d{2}");
+
+    private final AiScheduleRecommendationRepository recommendationRepository;
+    private final ProjectRepository projectRepository;
+    private final WorkPlanRepository workPlanRepository;
+    private final AnalysisService analysisService;
+    private final ObjectMapper objectMapper;
+    private final OpenAiScheduleRecommendationClient openAiClient;
+
+    @Transactional
+    public AiScheduleRecommendationDto.Res create(AiScheduleRecommendationDto.CreateReq req) {
+        Project project = projectRepository.findById(req.getProjectId())
+                .orElseThrow(() -> new RuntimeException("Project not found. id=" + req.getProjectId()));
+        WorkPlan monthlyWorkPlan = workPlanRepository.findById(req.getMonthlyWorkPlanId())
+                .orElseThrow(() -> new RuntimeException("Monthly work plan not found. id=" + req.getMonthlyWorkPlanId()));
+
+        if (monthlyWorkPlan.getPlanType() != PlanType.MONTHLY) {
+            throw new IllegalArgumentException("AI schedule recommendation requires a monthly work plan.");
+        }
+
+        Map<String, Object> context = buildContext(project, monthlyWorkPlan);
+        AiScheduleRecommendation recommendation = recommendationRepository.save(
+                AiScheduleRecommendation.pending(project, monthlyWorkPlan, toJson(context))
+        );
+
+        try {
+            Map<String, Object> result = openAiClient.generate(context);
+            validateResult(recommendation, result);
+            recommendation.markSuccess(toJson(result));
+        } catch (Exception e) {
+            recommendation.markFailed(e.getMessage());
+        }
+
+        return AiScheduleRecommendationDto.Res.from(recommendation);
+    }
+
+    public AiScheduleRecommendationDto.Res get(Long id) {
+        return AiScheduleRecommendationDto.Res.from(findRecommendation(id));
+    }
+
+    public List<AiScheduleRecommendationDto.Res> list(Long projectId) {
+        return recommendationRepository.findAllByProject_IdxOrderByCreatedAtDesc(projectId)
+                .stream()
+                .map(AiScheduleRecommendationDto.Res::from)
+                .toList();
+    }
+
+    @Transactional
+    public AiScheduleRecommendationDto.Res complete(
+            Long id,
+            AiScheduleRecommendationDto.CompleteReq req
+    ) {
+        AiScheduleRecommendation recommendation = findRecommendation(id);
+        Map<String, Object> result = normalizeResult(req);
+        validateResult(recommendation, result);
+        recommendation.markSuccess(toJson(result));
+        return AiScheduleRecommendationDto.Res.from(recommendation);
+    }
+
+    @Transactional
+    public AiScheduleRecommendationDto.Res fail(Long id, AiScheduleRecommendationDto.FailReq req) {
+        AiScheduleRecommendation recommendation = findRecommendation(id);
+        String message = req.getErrorMessage() == null || req.getErrorMessage().isBlank()
+                ? "AI recommendation failed."
+                : req.getErrorMessage();
+        recommendation.markFailed(message);
+        return AiScheduleRecommendationDto.Res.from(recommendation);
+    }
+
+    private Map<String, Object> buildContext(Project project, WorkPlan monthlyWorkPlan) {
+        List<WorkPlan> childPlans = workPlanRepository.findAllByParentWorkPlan_Idx(monthlyWorkPlan.getIdx());
+        List<Map<String, Object>> recoveryCandidates = childPlans.stream()
+                .filter(this::isActionableRecoveryCandidate)
+                .map(this::toRecoveryCandidateContext)
+                .toList();
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("project", toProjectContext(project));
+        context.put("monthlyWorkPlan", toWorkPlanContext(monthlyWorkPlan));
+        context.put("delayRisk", findDelayRisk(project.getIdx(), monthlyWorkPlan.getIdx()));
+        context.put("childWorkPlans", childPlans.stream().map(this::toWorkPlanContext).toList());
+        context.put("recoveryCandidates", recoveryCandidates);
+        context.put("guardrails", List.of(
+                "Return JSON only.",
+                "Use only workPlanId values from recoveryCandidates.",
+                "If recoveryCandidates is empty, return an empty detailChanges array.",
+                "Do not modify completed, unrelated, zero-worker, zero-man-hour, or date-missing work plans.",
+                "Recommend the nearest actionable candidates first and return at most 2 detailChanges.",
+                "Do not create new work names. Preserve the original name and append only a short concrete suffix when needed.",
+                "Keep recommended work time inside HH:mm ~ HH:mm format.",
+                "Prefer extending work time before increasing workers. Do not increase workers by more than 30% or 2 people.",
+                "Do not copy previous [승인 변경 반영] audit text into recommendedNote.",
+                "recommendedNote must be concrete field work guidance based on the existing note.",
+                "The result is a recommendation only; schedule changes require human approval."
+        ));
+        return context;
+    }
+
+    private Map<String, Object> toProjectContext(Project project) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("projectId", project.getIdx());
+        data.put("name", project.getName());
+        data.put("location", project.getLocation());
+        data.put("startDate", project.getStartDate());
+        data.put("endDate", project.getEndDate());
+        return data;
+    }
+
+    private Map<String, Object> toWorkPlanContext(WorkPlan workPlan) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("workPlanId", workPlan.getIdx());
+        data.put("parentWorkPlanId", workPlan.getParentWorkPlan() != null
+                ? workPlan.getParentWorkPlan().getIdx()
+                : null);
+        data.put("name", workPlan.getName());
+        data.put("trade", workPlan.getTrade() != null ? workPlan.getTrade().name() : null);
+        data.put("location", workPlan.getLocation());
+        data.put("planType", workPlan.getPlanType() != null ? workPlan.getPlanType().name() : null);
+        data.put("status", workPlan.getStatus() != null ? workPlan.getStatus().name() : null);
+        data.put("startDate", workPlan.getStartDate());
+        data.put("endDate", workPlan.getEndDate());
+        data.put("effectiveEndDate", workPlan.effectiveEndDate());
+        data.put("requiredCount", workPlan.getRequiredCount());
+        data.put("workersDisplay", workPlan.workersDisplay());
+        data.put("equipmentDisplay", workPlan.equipmentDisplay());
+        data.put("note", workPlan.getNote());
+        data.put("originalWorkTime", extractWorkTime(workPlan));
+        data.put("actionableRecoveryCandidate", isActionableRecoveryCandidate(workPlan));
+        return data;
+    }
+
+    private Map<String, Object> toRecoveryCandidateContext(WorkPlan workPlan) {
+        Map<String, Object> data = toWorkPlanContext(workPlan);
+        data.put("originalName", workPlan.getName());
+        data.put("originalRequiredCount", workPlan.getRequiredCount());
+        data.put("originalNote", sanitizeNote(workPlan.getNote()));
+        return data;
+    }
+
+    private boolean isActionableRecoveryCandidate(WorkPlan workPlan) {
+        return workPlan != null
+                && workPlan.getIdx() != null
+                && workPlan.getStartDate() != null
+                && workPlan.getEndDate() != null
+                && workPlan.getRequiredCount() != null
+                && workPlan.getRequiredCount() > 0;
+    }
+
+    private String extractWorkTime(WorkPlan workPlan) {
+        String note = workPlan == null ? "" : String.valueOf(workPlan.getNote() == null ? "" : workPlan.getNote());
+        java.util.regex.Matcher matcher = WORK_TIME_PATTERN.matcher(note);
+        if (matcher.find()) {
+            return matcher.group().replaceAll("\\s*(?:~|\\uFF5E)\\s*", " ~ ");
+        }
+        return "07:00 ~ 17:00";
+    }
+
+    private String sanitizeNote(String note) {
+        if (note == null || note.isBlank()) return "";
+        int markerIndex = note.indexOf("[승인 변경 반영]");
+        return markerIndex >= 0 ? note.substring(0, markerIndex).trim() : note.trim();
+    }
+
+    private Map<String, Object> findDelayRisk(Long projectId, Long monthlyWorkPlanId) {
+        return analysisService.getDelayRiskTasks(projectId, null)
+                .stream()
+                .filter(item -> monthlyWorkPlanId.equals(item.getWorkPlanId()))
+                .findFirst()
+                .map(this::toDelayRiskContext)
+                .orElseGet(LinkedHashMap::new);
+    }
+
+    private Map<String, Object> toDelayRiskContext(AnalysisDto.DelayRiskDetailRes item) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("workPlanId", item.getWorkPlanId());
+        data.put("tradeProcessId", item.getTradeProcessId());
+        data.put("process", item.getProcess());
+        data.put("tradeName", item.getTradeName());
+        data.put("name", item.getName());
+        data.put("location", item.getLocation());
+        data.put("plannedPct", item.getPlannedPct());
+        data.put("actualPct", item.getActualPct());
+        data.put("diff", item.getDiff());
+        data.put("status", item.getStatus());
+        data.put("risk", item.getRisk());
+        data.put("expectedDelayDays", item.getExpectedDelayDays());
+        data.put("actualSource", item.getActualSource());
+        data.put("latestReportDate", item.getLatestReportDate());
+        data.put("analysisDate", item.getAnalysisDate());
+        data.put("cause", item.getCause());
+        return data;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> normalizeResult(AiScheduleRecommendationDto.CompleteReq req) {
+        if (req.getResult() != null && !req.getResult().isEmpty()) {
+            return req.getResult();
+        }
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("changeSummary", req.getChangeSummary() != null
+                ? req.getChangeSummary()
+                : new LinkedHashMap<>());
+        result.put("detailChanges", req.getDetailChanges() != null
+                ? req.getDetailChanges()
+                : new ArrayList<>());
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateResult(AiScheduleRecommendation recommendation, Map<String, Object> result) {
+        Object rawDetailChanges = result.get("detailChanges");
+        if (!(rawDetailChanges instanceof List<?> detailChanges)) {
+            Object nestedSummary = result.get("recommendation");
+            if (nestedSummary instanceof Map<?, ?> nested) {
+                rawDetailChanges = nested.get("detailChanges");
+            }
+        }
+
+        if (!(rawDetailChanges instanceof List<?> detailChanges)) {
+            throw new IllegalArgumentException("AI result must include detailChanges array.");
+        }
+
+        for (Object item : detailChanges) {
+            if (!(item instanceof Map<?, ?> detail)) {
+                throw new IllegalArgumentException("Each detailChange must be an object.");
+            }
+            validateDetailChange(recommendation, (Map<String, Object>) detail);
+        }
+    }
+
+    private void validateDetailChange(
+            AiScheduleRecommendation recommendation,
+            Map<String, Object> detail
+    ) {
+        Long workPlanId = toLong(detail.get("workPlanId"));
+        if (workPlanId == null) {
+            throw new IllegalArgumentException("detailChange.workPlanId is required.");
+        }
+
+        WorkPlan workPlan = workPlanRepository.findById(workPlanId)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown workPlanId: " + workPlanId));
+
+        Long parentId = workPlan.getParentWorkPlan() != null ? workPlan.getParentWorkPlan().getIdx() : null;
+        if (!recommendation.getMonthlyWorkPlan().getIdx().equals(parentId)
+                && !recommendation.getMonthlyWorkPlan().getIdx().equals(workPlan.getIdx())) {
+            throw new IllegalArgumentException("workPlanId is outside the requested monthly work plan: " + workPlanId);
+        }
+
+        if (!isActionableRecoveryCandidate(workPlan)) {
+            throw new IllegalArgumentException("workPlanId is not an actionable recovery candidate: " + workPlanId);
+        }
+
+        Integer recommendedCount = toInteger(detail.get("recommendedRequiredCount"));
+        if (recommendedCount != null && (recommendedCount < 0 || recommendedCount > 100)) {
+            throw new IllegalArgumentException("recommendedRequiredCount must be between 0 and 100.");
+        }
+        if (recommendedCount != null) {
+            int currentCount = Math.max(0, workPlan.getRequiredCount() == null ? 0 : workPlan.getRequiredCount());
+            int maxIncrease = Math.max(2, (int) Math.ceil(currentCount * 0.3));
+            if (recommendedCount < currentCount || recommendedCount > currentCount + maxIncrease) {
+                throw new IllegalArgumentException(
+                        "recommendedRequiredCount must stay within the current count and a realistic recovery increase.");
+            }
+        }
+
+        String recommendedWorkTime = asText(detail.get("recommendedWorkTime"));
+        if (recommendedWorkTime != null
+                && !recommendedWorkTime.isBlank()
+                && !WORK_TIME_PATTERN.matcher(recommendedWorkTime).matches()) {
+            throw new IllegalArgumentException("recommendedWorkTime must use HH:mm ~ HH:mm format.");
+        }
+    }
+
+    private AiScheduleRecommendation findRecommendation(Long id) {
+        return recommendationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("AI schedule recommendation not found. id=" + id));
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize AI recommendation data.", e);
+        }
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number number) return number.longValue();
+        try {
+            String text = String.valueOf(value).trim();
+            return text.isBlank() ? null : Long.parseLong(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Integer toInteger(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number number) return number.intValue();
+        try {
+            String text = String.valueOf(value).trim();
+            return text.isBlank() ? null : Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private String asText(Object value) {
+        return value == null ? null : String.valueOf(value).trim();
+    }
+}

--- a/src/main/java/org/example/dndn/ai/OpenAiScheduleRecommendationClient.java
+++ b/src/main/java/org/example/dndn/ai/OpenAiScheduleRecommendationClient.java
@@ -1,0 +1,174 @@
+package org.example.dndn.ai;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiScheduleRecommendationClient {
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    @Value("${openai.model:gpt-5.5}")
+    private String model;
+
+    private final WebClient webClient = WebClient.builder()
+            .baseUrl("https://api.openai.com/v1")
+            .build();
+
+    public Map<String, Object> generate(Map<String, Object> context) {
+        try {
+            Map<String, Object> requestBody = Map.of(
+                    "model", model,
+                    "input", List.of(
+                            Map.of(
+                                    "role", "system",
+                                    "content", List.of(
+                                            Map.of(
+                                                    "type", "input_text",
+                                                    "text", buildSystemPrompt()
+                                            )
+                                    )
+                            ),
+                            Map.of(
+                                    "role", "user",
+                                    "content", List.of(
+                                            Map.of(
+                                                    "type", "input_text",
+                                                    "text", objectMapper.writeValueAsString(context)
+                                            )
+                                    )
+                            )
+                    ),
+                    "text", Map.of(
+                            "format", buildJsonSchema()
+                    )
+            );
+
+            String response = webClient.post()
+                    .uri("/responses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer " + apiKey)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            String jsonText = extractOutputText(response);
+            return objectMapper.readValue(jsonText, new TypeReference<LinkedHashMap<String, Object>>() {});
+        } catch (Exception e) {
+            throw new RuntimeException("OpenAI schedule recommendation failed.", e);
+        }
+    }
+
+    private String buildSystemPrompt() {
+        return """
+                You are a construction schedule recovery assistant for DnDn.
+                Use the supplied project, monthly work plan, delay risk, and child work plans.
+
+                Rules:
+                1. Return JSON only in the requested schema.
+                2. Recommend changes only for workPlanId values included in recoveryCandidates.
+                3. If recoveryCandidates is empty, return "detailChanges": [].
+                4. Do not invent workPlanId values.
+                5. Do not recommend changing completed, unrelated, zero-worker, zero-man-hour, or date-missing work.
+                6. Prefer keeping the monthly plan end date unless the delay cannot be recovered safely.
+                7. Work time must use "HH:mm ~ HH:mm".
+                8. recommendedRequiredCount must be realistic: keep current count or increase by at most 30% / 2 workers.
+                9. Return at most 2 detailChanges. Choose the nearest actionable recovery candidates first.
+                10. Do not rename work into vague phrases such as 집중 시공, 조기 완료, 확인 강화, 투입 unless the original work name is preserved.
+                11. recommendedName should usually be the original name. If changed, append a short concrete suffix only.
+                12. recommendedNote must be concrete field guidance based on originalNote and must not copy previous "[승인 변경 반영]" audit text.
+                13. Write Korean B2B operations text. Be concise, factual, and non-promotional.
+                """;
+    }
+
+    private Map<String, Object> buildJsonSchema() {
+        return Map.of(
+                "type", "json_schema",
+                "name", "schedule_recommendation_result",
+                "strict", true,
+                "schema", Map.of(
+                        "type", "object",
+                        "additionalProperties", false,
+                        "properties", Map.of(
+                                "changeSummary", Map.of(
+                                        "type", "object",
+                                        "additionalProperties", false,
+                                        "properties", Map.of(
+                                                "summary", Map.of("type", "string"),
+                                                "expectedEffect", Map.of("type", "string"),
+                                                "basis", Map.of("type", "string"),
+                                                "addDays", Map.of("type", "integer"),
+                                                "recommendedWorkers", Map.of("type", "integer")
+                                        ),
+                                        "required", List.of(
+                                                "summary",
+                                                "expectedEffect",
+                                                "basis",
+                                                "addDays",
+                                                "recommendedWorkers"
+                                        )
+                                ),
+                                "detailChanges", Map.of(
+                                        "type", "array",
+                                        "items", Map.of(
+                                                "type", "object",
+                                                "additionalProperties", false,
+                                                "properties", Map.of(
+                                                        "workPlanId", Map.of("type", "integer"),
+                                                        "recommendedName", Map.of("type", "string"),
+                                                        "recommendedRequiredCount", Map.of("type", "integer"),
+                                                        "recommendedWorkTime", Map.of("type", "string"),
+                                                        "recommendedNote", Map.of("type", "string"),
+                                                        "manHourAdjustmentReason", Map.of("type", "string")
+                                                ),
+                                                "required", List.of(
+                                                        "workPlanId",
+                                                        "recommendedName",
+                                                        "recommendedRequiredCount",
+                                                        "recommendedWorkTime",
+                                                        "recommendedNote",
+                                                        "manHourAdjustmentReason"
+                                                )
+                                        )
+                                )
+                        ),
+                        "required", List.of("changeSummary", "detailChanges")
+                )
+        );
+    }
+
+    private String extractOutputText(String response) {
+        try {
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode output = root.path("output");
+
+            for (JsonNode item : output) {
+                JsonNode content = item.path("content");
+                for (JsonNode contentItem : content) {
+                    if (contentItem.has("text")) {
+                        return contentItem.get("text").asText();
+                    }
+                }
+            }
+
+            throw new RuntimeException("OpenAI response output text not found.");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse OpenAI response.", e);
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendation.java
+++ b/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendation.java
@@ -1,0 +1,61 @@
+package org.example.dndn.ai.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.dndn.common.model.BaseEntity;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+@Table(name = "ai_schedule_recommendation")
+public class AiScheduleRecommendation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "monthly_work_plan_id", nullable = false)
+    private WorkPlan monthlyWorkPlan;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AiScheduleRecommendationStatus status;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String contextJson;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String resultJson;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    public static AiScheduleRecommendation pending(Project project, WorkPlan monthlyWorkPlan, String contextJson) {
+        return AiScheduleRecommendation.builder()
+                .project(project)
+                .monthlyWorkPlan(monthlyWorkPlan)
+                .status(AiScheduleRecommendationStatus.PENDING)
+                .contextJson(contextJson)
+                .build();
+    }
+
+    public void markSuccess(String resultJson) {
+        this.status = AiScheduleRecommendationStatus.SUCCESS;
+        this.resultJson = resultJson;
+        this.errorMessage = null;
+    }
+
+    public void markFailed(String errorMessage) {
+        this.status = AiScheduleRecommendationStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendationDto.java
+++ b/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendationDto.java
@@ -1,0 +1,76 @@
+package org.example.dndn.ai.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class AiScheduleRecommendationDto {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class CreateReq {
+        private Long projectId;
+        private Long monthlyWorkPlanId;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class CompleteReq {
+        private Map<String, Object> result;
+        private Map<String, Object> changeSummary;
+        private List<Map<String, Object>> detailChanges;
+    }
+
+    @Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class FailReq {
+        private String errorMessage;
+    }
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Res {
+        private Long id;
+        private Long projectId;
+        private Long monthlyWorkPlanId;
+        private String monthlyWorkPlanName;
+        private String status;
+        private Map<String, Object> context;
+        private Map<String, Object> result;
+        private String errorMessage;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public static Res from(AiScheduleRecommendation entity) {
+            return Res.builder()
+                    .id(entity.getIdx())
+                    .projectId(entity.getProject() != null ? entity.getProject().getIdx() : null)
+                    .monthlyWorkPlanId(entity.getMonthlyWorkPlan() != null
+                            ? entity.getMonthlyWorkPlan().getIdx()
+                            : null)
+                    .monthlyWorkPlanName(entity.getMonthlyWorkPlan() != null
+                            ? entity.getMonthlyWorkPlan().getName()
+                            : "")
+                    .status(entity.getStatus() != null ? entity.getStatus().name() : "")
+                    .context(readObject(entity.getContextJson()))
+                    .result(readObject(entity.getResultJson()))
+                    .errorMessage(entity.getErrorMessage())
+                    .createdAt(entity.getCreatedAt())
+                    .updatedAt(entity.getUpdatedAt())
+                    .build();
+        }
+
+        private static Map<String, Object> readObject(String json) {
+            if (json == null || json.isBlank()) return Collections.emptyMap();
+
+            try {
+                return OBJECT_MAPPER.readValue(json, new TypeReference<>() {});
+            } catch (Exception e) {
+                return Collections.emptyMap();
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendationStatus.java
+++ b/src/main/java/org/example/dndn/ai/model/AiScheduleRecommendationStatus.java
@@ -1,0 +1,7 @@
+package org.example.dndn.ai.model;
+
+public enum AiScheduleRecommendationStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/org/example/dndn/analysis/AnalysisService.java
+++ b/src/main/java/org/example/dndn/analysis/AnalysisService.java
@@ -13,8 +13,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -23,30 +27,43 @@ public class AnalysisService {
 
     private static final String ACTUAL_SOURCE_DAILY_REPORT = "DAILY_REPORT";
     private static final String ACTUAL_SOURCE_NONE = "NONE";
+    private static final ZoneId ANALYSIS_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalTime DEFAULT_WORK_END_TIME = LocalTime.of(18, 0);
+    private static final Pattern WORK_TIME_RANGE_PATTERN = Pattern.compile(
+            "(\\d{1,2}:\\d{2})\\s*(?:~|\\uFF5E)\\s*(\\d{1,2}:\\d{2})"
+    );
 
     private final TradeProcessRepository tradeProcessRepository;
     private final WorkPlanRepository workPlanRepository;
     private final DailyReportRepository dailyReportRepository;
 
-    // ─────────────────────────────────────────────
-    // 1. 공정 진척률 비교
-    // TradeProcess 기준
-    // 예: 기초 콘크리트 타설 전체 진척률
-    // ─────────────────────────────────────────────
+    // ?????????????????????????????????????????????
+    // 1. 怨듭젙 吏꾩쿃瑜?鍮꾧탳
+    // TradeProcess 湲곗?
+    // ?? 湲곗큹 肄섑겕由ы듃 ????꾩껜 吏꾩쿃瑜?
+    // ?????????????????????????????????????????????
 
     public List<AnalysisDto.ProcessProgressRes> getProgressList(Long projectId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ANALYSIS_ZONE);
 
         return tradeProcessRepository
                 .findAllByMasterSchedule_Project_Idx(projectId)
                 .stream()
+                .filter(tp -> !isMilestoneProcess(tp))
                 .map(tp -> buildProgressRes(tp, today))
                 .toList();
     }
 
+    private boolean isMilestoneProcess(TradeProcess tradeProcess) {
+        if (tradeProcess == null) return false;
+        if (Boolean.TRUE.equals(tradeProcess.getIsMilestone())) return true;
+        return "마일스톤".equals(String.valueOf(tradeProcess.getTradeName()).trim());
+    }
+
     private AnalysisDto.ProcessProgressRes buildProgressRes(TradeProcess tp, LocalDate today) {
-        double plannedPct = calcPlannedPct(tp.getPlannedStart(), tp.getPlannedEnd(), today);
         ActualProgressSnapshot actualProgress = calcActualProgressByTradeProcess(tp.getIdx(), today);
+        LocalDate referenceDate = resolveReferenceDateForTradeProcess(tp.getIdx(), actualProgress, today);
+        double plannedPct = calcPlannedPct(tp.getPlannedStart(), tp.getPlannedEnd(), referenceDate);
         double actualPct = actualProgress.actualPct();
         double diff = roundPct(plannedPct - actualPct);
 
@@ -54,7 +71,7 @@ public class AnalysisService {
                 diff,
                 tp.getPlannedStart(),
                 tp.getPlannedEnd(),
-                today,
+                referenceDate,
                 actualPct
         );
 
@@ -62,7 +79,7 @@ public class AnalysisService {
                 diff,
                 tp.getPlannedStart(),
                 tp.getPlannedEnd(),
-                today,
+                referenceDate,
                 actualPct
         );
 
@@ -74,37 +91,38 @@ public class AnalysisService {
                 .plannedStart(tp.getPlannedStart())
                 .plannedEnd(tp.getPlannedEnd())
                 .actualStart(tp.getPlannedStart())
-                .forecastEnd(calcForecastEnd(tp.getPlannedStart(), tp.getPlannedEnd(), actualPct, today))
+                .forecastEnd(calcForecastEnd(tp.getPlannedStart(), tp.getPlannedEnd(), actualPct, referenceDate))
                 .plannedPct(plannedPct)
                 .actualPct(actualPct)
                 .actualSource(actualProgress.source())
                 .latestReportDate(actualProgress.reportDate())
+                .analysisDate(referenceDate)
                 .diff(diff)
                 .status(status)
                 .risk(risk)
-                .actualWorkers(calcActualWorkersByTradeProcess(tp.getIdx(), today))
+                .actualWorkers(calcActualWorkersByTradeProcess(tp.getIdx(), referenceDate))
                 .build();
     }
 
-    // ─────────────────────────────────────────────
-    // 2. 지연 위험 세부 작업
-    // MONTHLY WorkPlan 기준
-    // 예: 101동 기초 콘크리트 타설
+    // ?????????????????????????????????????????????
+    // 2. 吏???꾪뿕 ?몃? ?묒뾽
+    // MONTHLY WorkPlan 湲곗?
+    // ?? 101??湲곗큹 肄섑겕由ы듃 ???
     //
-    // 자식 WEEKLY WorkPlan
-    // 예: 5/1 점검, 5/2 장비 반입, 5/3 1구간 타설
-    // ─────────────────────────────────────────────
+    // ?먯떇 WEEKLY WorkPlan
+    // ?? 5/1 ?먭?, 5/2 ?λ퉬 諛섏엯, 5/3 1援ш컙 ???
+    // ?????????????????????????????????????????????
 
     public List<AnalysisDto.DelayRiskDetailRes> getDelayRiskTasks(Long projectId, Long tradeProcessId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ANALYSIS_ZONE);
 
         return workPlanRepository
                 .findAllByTradeProcess_MasterSchedule_Project_Idx(projectId)
                 .stream()
-                // 101동 기초 콘크리트 타설 같은 세부 작업
+                // 101??湲곗큹 肄섑겕由ы듃 ???媛숈? ?몃? ?묒뾽
                 .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
 
-                // 특정 공정 선택 시 해당 공정의 세부 작업만 조회
+                // ?뱀젙 怨듭젙 ?좏깮 ???대떦 怨듭젙???몃? ?묒뾽留?議고쉶
                 .filter(wp -> tradeProcessId == null
                         || (wp.getTradeProcess() != null
                         && wp.getTradeProcess().getIdx().equals(tradeProcessId)))
@@ -113,7 +131,7 @@ public class AnalysisService {
                 .filter(task -> isDelayRiskTask(
                         task.getDate(),
                         task.getEffectiveEnd(),
-                        today,
+                        task.getAnalysisDate() != null ? task.getAnalysisDate() : today,
                         task.getDiff(),
                         task.getActualPct()
                 ))
@@ -121,13 +139,14 @@ public class AnalysisService {
     }
 
     private AnalysisDto.DelayRiskDetailRes buildDelayRiskTaskRes(WorkPlan parentPlan, LocalDate today) {
+        ActualProgressSnapshot actualProgress = getActualProgressByMonthlyPlan(parentPlan, today);
+        LocalDate referenceDate = resolveReferenceDateForMonthlyPlan(parentPlan, actualProgress, today);
         double plannedPct = calcPlannedPct(
                 parentPlan.getStartDate(),
                 parentPlan.effectiveEndDate(),
-                today
+                referenceDate
         );
 
-        ActualProgressSnapshot actualProgress = getActualProgressByMonthlyPlan(parentPlan, today);
         double actualPct = actualProgress.actualPct();
         double diff = roundPct(plannedPct - actualPct);
 
@@ -135,7 +154,7 @@ public class AnalysisService {
                 diff,
                 parentPlan.getStartDate(),
                 parentPlan.effectiveEndDate(),
-                today,
+                referenceDate,
                 actualPct
         );
 
@@ -143,20 +162,20 @@ public class AnalysisService {
                 diff,
                 parentPlan.getStartDate(),
                 parentPlan.effectiveEndDate(),
-                today,
+                referenceDate,
                 actualPct
         );
 
         List<WorkPlan> childPlans = workPlanRepository.findAllByParentWorkPlan_Idx(parentPlan.getIdx());
 
         int actualWorkers = childPlans.stream()
-                .mapToInt(child -> getLatestActualWorkersByWorkPlan(child.getIdx(), today))
+                .mapToInt(child -> getLatestActualWorkersByWorkPlan(child.getIdx(), referenceDate))
                 .sum();
 
-        String latestIssue = getLatestIssueFromChildPlans(parentPlan.getIdx(), today);
+        String latestIssue = getLatestIssueFromChildPlans(parentPlan.getIdx(), referenceDate);
         String cause = actualProgress.hasDailyReport()
                 ? latestIssue
-                : "공사일보의 월간 세부계획 진척률 미작성";
+                : "\uacf5\uc0ac\uc77c\ubcf4 \uae30\uc900 \uc6d4\uac04 \uc138\ubd80\uacc4\ud68d \uc9c4\ucc99\ub960 \ubbf8\uc791\uc131";
 
         return AnalysisDto.DelayRiskDetailRes.builder()
                 .workPlanId(parentPlan.getIdx())
@@ -180,6 +199,7 @@ public class AnalysisService {
                 .actualSource(actualProgress.source())
                 .latestReportDate(actualProgress.reportDate())
                 .dailyReportId(actualProgress.reportId())
+                .analysisDate(referenceDate)
                 .diff(diff)
                 .status(status)
                 .risk(risk)
@@ -200,9 +220,107 @@ public class AnalysisService {
                 .build();
     }
 
-    // ─────────────────────────────────────────────
-    // 3. 실제 진척률 계산
-    // ─────────────────────────────────────────────
+    // ?????????????????????????????????????????????
+    // 3. ?ㅼ젣 吏꾩쿃瑜?怨꾩궛
+    // ?????????????????????????????????????????????
+
+    private LocalDate resolveReferenceDateForTradeProcess(
+            Long tradeProcessId,
+            ActualProgressSnapshot actualProgress,
+            LocalDate today
+    ) {
+        if (hasDailyReportOn(actualProgress, today)) return today;
+
+        LocalTime workEndTime = resolveTradeProcessWorkEndTime(tradeProcessId, today);
+        if (LocalTime.now(ANALYSIS_ZONE).isBefore(workEndTime)) {
+            return trustedReferenceDate(actualProgress, today);
+        }
+
+        return today;
+    }
+
+    private LocalDate resolveReferenceDateForMonthlyPlan(
+            WorkPlan monthlyPlan,
+            ActualProgressSnapshot actualProgress,
+            LocalDate today
+    ) {
+        if (hasDailyReportOn(actualProgress, today)) return today;
+
+        LocalTime workEndTime = resolveMonthlyPlanWorkEndTime(monthlyPlan, today);
+        if (LocalTime.now(ANALYSIS_ZONE).isBefore(workEndTime)) {
+            return trustedReferenceDate(actualProgress, today);
+        }
+
+        return today;
+    }
+
+    private boolean hasDailyReportOn(ActualProgressSnapshot actualProgress, LocalDate date) {
+        return actualProgress != null
+                && actualProgress.hasDailyReport()
+                && date != null
+                && date.equals(actualProgress.reportDate());
+    }
+
+    private LocalDate trustedReferenceDate(ActualProgressSnapshot actualProgress, LocalDate today) {
+        if (actualProgress != null && actualProgress.reportDate() != null) {
+            return actualProgress.reportDate();
+        }
+        return today.minusDays(1);
+    }
+
+    private LocalTime resolveTradeProcessWorkEndTime(Long tradeProcessId, LocalDate date) {
+        if (tradeProcessId == null) return DEFAULT_WORK_END_TIME;
+
+        return workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId)
+                .stream()
+                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .map(monthlyPlan -> resolveMonthlyPlanWorkEndTime(monthlyPlan, date))
+                .max(LocalTime::compareTo)
+                .orElse(DEFAULT_WORK_END_TIME);
+    }
+
+    private LocalTime resolveMonthlyPlanWorkEndTime(WorkPlan monthlyPlan, LocalDate date) {
+        if (monthlyPlan == null || monthlyPlan.getIdx() == null) return DEFAULT_WORK_END_TIME;
+
+        return workPlanRepository.findAllByParentWorkPlan_Idx(monthlyPlan.getIdx())
+                .stream()
+                .filter(child -> containsDate(child, date))
+                .map(child -> parseWorkEndTime(child.getNote()))
+                .filter(time -> time != null)
+                .max(LocalTime::compareTo)
+                .orElse(DEFAULT_WORK_END_TIME);
+    }
+
+    private boolean containsDate(WorkPlan workPlan, LocalDate date) {
+        if (workPlan == null || date == null) return false;
+        LocalDate start = workPlan.getStartDate();
+        LocalDate end = workPlan.getEndDate();
+        if (start == null || end == null) return false;
+        return !date.isBefore(start) && !date.isAfter(end);
+    }
+
+    private LocalTime parseWorkEndTime(String note) {
+        if (note == null || note.isBlank()) return null;
+
+        Matcher matcher = WORK_TIME_RANGE_PATTERN.matcher(note);
+        LocalTime latestEnd = null;
+        while (matcher.find()) {
+            LocalTime parsedEnd = parseTime(matcher.group(2));
+            if (parsedEnd != null) {
+                latestEnd = parsedEnd;
+            }
+        }
+        return latestEnd;
+    }
+
+    private LocalTime parseTime(String value) {
+        if (value == null || value.isBlank()) return null;
+        try {
+            return LocalTime.parse(value.trim());
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
     private ActualProgressSnapshot calcActualProgressByTradeProcess(Long tradeProcessId, LocalDate today) {
         List<WorkPlan> plans = workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId);
@@ -266,9 +384,9 @@ public class AnalysisService {
         return roundPct(clamped);
     }
 
-    // ─────────────────────────────────────────────
-    // 4. 실제 투입 인원 / 이슈
-    // ─────────────────────────────────────────────
+    // ?????????????????????????????????????????????
+    // 4. ?ㅼ젣 ?ъ엯 ?몄썝 / ?댁뒋
+    // ?????????????????????????????????????????????
 
     private int calcActualWorkersByTradeProcess(Long tradeProcessId, LocalDate today) {
         return workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId)
@@ -313,9 +431,9 @@ public class AnalysisService {
                 .orElse("");
     }
 
-    // ─────────────────────────────────────────────
-    // 5. 계획 진척률 / 예상 종료일
-    // ─────────────────────────────────────────────
+    // ?????????????????????????????????????????????
+    // 5. 怨꾪쉷 吏꾩쿃瑜?/ ?덉긽 醫낅즺??
+    // ?????????????????????????????????????????????
 
     private double calcPlannedPct(LocalDate start, LocalDate end, LocalDate today) {
         if (start == null || end == null) return 0.0;
@@ -384,40 +502,40 @@ public class AnalysisService {
     }
 
     private String resolveFollowEffect(WorkPlan workPlan, String risk) {
-        if ("매우 높음".equals(risk) || "높음".equals(risk)) {
-            return "후속 공정 영향 검토 필요";
+        if ("\ub9e4\uc6b0 \ub192\uc74c".equals(risk) || "\ub192\uc74c".equals(risk)) {
+            return "\ud6c4\uc18d \uacf5\uc815 \uc601\ud5a5 \uac80\ud1a0 \ud544\uc694";
         }
-        return "영향 낮음";
+        return "\uc601\ud5a5 \ub0ae\uc74c";
     }
 
-    // ─────────────────────────────────────────────
-    // 6. 상태 / 위험도 판단
-    // ─────────────────────────────────────────────
+    // ?????????????????????????????????????????????
+    // 6. ?곹깭 / ?꾪뿕???먮떒
+    // ?????????????????????????????????????????????
 
     private String classifyStatus(double diff, LocalDate start, LocalDate end, LocalDate today, double actualPct) {
-        if (actualPct >= 100) return "완료";
+        if (actualPct >= 100) return "\uc644\ub8cc";
 
-        if (isOverdueNotDone(end, today, actualPct)) return "지연";
-        if (diff >= 15) return "지연";
-        if (diff >= 10) return "지연 위험";
-        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "지연 위험";
-        if (diff >= 5) return "주의";
-        if (diff > 0) return "주의";
+        if (isOverdueNotDone(end, today, actualPct)) return "\uc9c0\uc5f0";
+        if (diff >= 15) return "\uc9c0\uc5f0";
+        if (diff >= 10) return "\uc9c0\uc5f0 \uc704\ud5d8";
+        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "\uc9c0\uc5f0 \uc704\ud5d8";
+        if (diff >= 5) return "\uc8fc\uc758";
+        if (diff > 0) return "\uc8fc\uc758";
 
-        return "정상";
+        return "\uc815\uc0c1";
     }
 
     private String classifyRisk(double diff, LocalDate start, LocalDate end, LocalDate today, double actualPct) {
-        if (actualPct >= 100) return "낮음";
+        if (actualPct >= 100) return "\ub0ae\uc74c";
 
-        if (isOverdueNotDone(end, today, actualPct)) return "매우 높음";
-        if (diff >= 20) return "매우 높음";
-        if (diff >= 15) return "높음";
-        if (diff >= 10) return "보통";
-        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "보통";
-        if (diff > 0) return "보통";
+        if (isOverdueNotDone(end, today, actualPct)) return "\ub9e4\uc6b0 \ub192\uc74c";
+        if (diff >= 20) return "\ub9e4\uc6b0 \ub192\uc74c";
+        if (diff >= 15) return "\ub192\uc74c";
+        if (diff >= 10) return "\ubcf4\ud1b5";
+        if (isNearDeadlineAndLow(start, end, today, actualPct)) return "\ubcf4\ud1b5";
+        if (diff > 0) return "\ubcf4\ud1b5";
 
-        return "낮음";
+        return "\ub0ae\uc74c";
     }
 
     private boolean isDelayRiskTask(
@@ -432,7 +550,7 @@ public class AnalysisService {
 
         if (start == null || end == null) return false;
 
-        // 아직 시작 전인 세부 작업은 지연 위험으로 보지 않음
+        // ?꾩쭅 ?쒖옉 ?꾩씤 ?몃? ?묒뾽? 吏???꾪뿕?쇰줈 蹂댁? ?딆쓬
         if (today.isBefore(start)) return false;
 
         return safeDiff > 0

--- a/src/main/java/org/example/dndn/analysis/model/AnalysisDto.java
+++ b/src/main/java/org/example/dndn/analysis/model/AnalysisDto.java
@@ -23,6 +23,7 @@ public class AnalysisDto {
         private Double actualPct;       // 실제 진척률 (DailyReport 누적)
         private String actualSource;    // DAILY_REPORT | NONE
         private LocalDate latestReportDate;
+        private LocalDate analysisDate;
         private Double diff;            // plannedPct - actualPct (양수 = 지연)
         private String status;          // 정상 / 주의 / 지연 위험 / 지연
         private String risk;            // 낮음 / 보통 / 높음 / 매우 높음
@@ -75,6 +76,7 @@ public class AnalysisDto {
         private String actualSource;    // DAILY_REPORT | NONE
         private LocalDate latestReportDate;
         private Long dailyReportId;
+        private LocalDate analysisDate;
         private Double diff;
         private String status;
         private String risk;

--- a/src/main/java/org/example/dndn/report/DailyReportService.java
+++ b/src/main/java/org/example/dndn/report/DailyReportService.java
@@ -61,6 +61,7 @@ public class DailyReportService {
                 progressIncrementPct,
                 monthlyProgressPct,
                 dto.getActualWorkerCount(),
+                nonBlank(dto.getLocation(), workPlan.getLocation()),
                 dto.getIssue(),
                 dto.getTodayWork(),
                 dto.getTomorrowPlan()
@@ -156,6 +157,11 @@ public class DailyReportService {
         return Math.max(0.0, Math.min(100.0, value));
     }
 
+    private String nonBlank(String value, String fallback) {
+        if (value != null && !value.isBlank()) return value;
+        return fallback != null ? fallback : "";
+    }
+
     // feat : 특정 일자 공사일보 목록 조회 및 DTO 변환
     @Transactional(readOnly = true)
     public List<ReportDto.Res> getReportsByDate(LocalDate date) {
@@ -170,6 +176,7 @@ public class DailyReportService {
                         .progressIncrementPct(r.getProgressIncrementPct())
                         .monthlyProgressPct(r.getMonthlyProgressPct())
                         .actualWorkerCount(r.getActualWorkerCount())
+                        .location(nonBlank(r.getLocation(), r.getWorkPlan().getLocation()))
                         .issue(r.getIssue())
                         .reportDate(r.getReportDate())
                         .todayWork(r.getTodayWork())

--- a/src/main/java/org/example/dndn/report/model/DailyReport.java
+++ b/src/main/java/org/example/dndn/report/model/DailyReport.java
@@ -4,49 +4,51 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.example.dndn.common.model.BaseEntity;
 import org.example.dndn.workplan.model.entity.WorkPlan;
+
 import java.time.LocalDate;
 
-// [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
-// feat : 공사일보 엔티티 클래스
 @Entity
 @Table(name = "daily_report")
-@Getter @Builder @NoArgsConstructor @AllArgsConstructor
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class DailyReport extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long idx; // feat : 공사일보 고유 식별자 PK
+    private Long idx;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "work_plan_idx")
-    private WorkPlan workPlan; // feat : 연관된 주간 작업 계획 FK
+    private WorkPlan workPlan;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "monthly_work_plan_idx")
-    private WorkPlan monthlyWorkPlan; // feat : 누적 진척률을 반영할 부모 월간 세부계획 FK
+    private WorkPlan monthlyWorkPlan;
 
-    private Double actualProgress; // feat : 전체 누적 진척률
+    private Double actualProgress;
 
-    private Double todayProgress; // feat : 금일 입력 진척률 (새로 추가된 컬럼)
+    private Double todayProgress;
 
-    private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영된 증가분
+    private Double progressIncrementPct;
 
-    private Double monthlyProgressPct; // feat : 반영 후 월간 세부계획 누적 진척률
+    private Double monthlyProgressPct;
 
-    private Integer actualWorkerCount; // feat : 금일 실제 투입 인원 수
+    private Integer actualWorkerCount;
 
-    private String issue; // feat : 특이사항 및 이슈
+    private String location;
 
-    private LocalDate reportDate; // feat : 공사일보 작성 일자
+    private String issue;
+
+    private LocalDate reportDate;
 
     @Column(columnDefinition = "TEXT")
-    private String todayWork; // feat : 금일 작업 완료 내용
+    private String todayWork;
 
     @Column(columnDefinition = "TEXT")
-    private String tomorrowPlan; // feat : 명일 작업 예정 내용
+    private String tomorrowPlan;
 
-    // [REPORT_003] 3단계 : 공사일보 제출(Upsert) 기본 로직 구현
-    // feat : 공사일보 정보 업데이트 메서드 (금일 진척률 반영)
     public void updateReport(
             WorkPlan monthlyWorkPlan,
             Double actualProgress,
@@ -54,6 +56,7 @@ public class DailyReport extends BaseEntity {
             Double progressIncrementPct,
             Double monthlyProgressPct,
             Integer actualWorkerCount,
+            String location,
             String issue,
             String todayWork,
             String tomorrowPlan
@@ -64,6 +67,7 @@ public class DailyReport extends BaseEntity {
         this.progressIncrementPct = progressIncrementPct;
         this.monthlyProgressPct = monthlyProgressPct;
         this.actualWorkerCount = actualWorkerCount;
+        this.location = location;
         this.issue = issue;
         this.todayWork = todayWork;
         this.tomorrowPlan = tomorrowPlan;

--- a/src/main/java/org/example/dndn/report/model/ReportDto.java
+++ b/src/main/java/org/example/dndn/report/model/ReportDto.java
@@ -1,75 +1,77 @@
 package org.example.dndn.report.model;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
+
 import java.time.LocalDate;
 import java.util.List;
 
-// feat : 공사일보 데이터 전송 및 반환용 DTO 클래스
 public class ReportDto {
 
-    // [REPORT_007] 7단계 : 명일 스케줄 투입 장비 연동 기능
-    // feat : 프론트에서 명일 투입 장비 배열을 받기 위한 DTO 클래스
-    @Getter @Setter @NoArgsConstructor @AllArgsConstructor
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class TomorrowEqDto {
-        private String type;    // feat : 장비 종류 (예: 굴삭기, 덤프트럭 등)
-        private Integer count;  // feat : 투입 장비 대수
+        private String type;
+        private Integer count;
     }
 
-    // [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
-    // feat : 프론트에서 백엔드로 공사일보 데이터를 생성/요청하기 위한 DTO 클래스 (Req)
-    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Req {
         @NotNull(message = "workPlanId is required")
-        private Long workPlanId;            // feat : 연관된 작업 계획(WorkPlan) 고유 식별자 FK
+        private Long workPlanId;
 
         @NotNull(message = "actualProgress is required")
-        private Double actualProgress;      // feat : 계산 완료된 전체 누적 진척률 (예: 12.5%)
+        private Double actualProgress;
 
-        private Double todayProgress;       // feat : 금일 입력된 진척률 (예: 사용자가 입력한 90%)
+        private Double todayProgress;
 
-        private Long monthlyWorkPlanId;     // feat : 누적 진척률을 반영할 부모 월간 세부계획 ID
-        private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영되는 증가분
-        private Double monthlyProgressPct;   // feat : 반영 후 월간 세부계획 누적 진척률
+        private Long monthlyWorkPlanId;
+        private Double progressIncrementPct;
+        private Double monthlyProgressPct;
 
         @NotNull(message = "actualWorkerCount is required")
-        private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
+        private Integer actualWorkerCount;
+
+        private String location;
 
         @NotBlank(message = "issue is required")
-        private String issue;               // feat : 특이사항 및 이슈
+        private String issue;
 
         @NotNull(message = "reportDate is required")
-        private LocalDate reportDate;       // feat : 공사일보 작성 일자
+        private LocalDate reportDate;
 
-        private String todayWork;           // feat : 금일 작업 완료 내용
-        private String tomorrowPlan;        // feat : 명일 작업 예정 내용
+        private String todayWork;
+        private String tomorrowPlan;
 
-        private Long tomorrowWorkPlanId;    // feat : 프론트엔드에서 선택한 '덮어쓸 대상 주간계획의 ID'를 받을 필드
-
-        // [REPORT_006] 6단계 : 명일 스케줄 투입 인원 연동 기능
-        // feat : 옵션 B 추가 데이터 (내일 일정 자동 생성용)
-        private Integer tomorrowWorkerCount; // feat : 명일 투입 예정 인원 수
-
-        // [REPORT_007] 7단계 : 명일 스케줄 투입 장비 연동 기능
-        private List<TomorrowEqDto> tomorrowEquipments; // feat : 명일 투입 예정 장비 목록 배열
+        private Long tomorrowWorkPlanId;
+        private Integer tomorrowWorkerCount;
+        private List<TomorrowEqDto> tomorrowEquipments;
     }
 
-    // [REPORT_001] 1단계 : 공사일보 기본 엔티티 및 DTO 설계
-    // feat : 프론트로 데이터를 반환하기 위한 응답용 DTO 클래스 (Res)
-    @Getter @Builder @NoArgsConstructor @AllArgsConstructor
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Res {
-        private Long idx;                   // feat : 공사일보 고유 식별자 PK
-        private Long workPlanId;            // feat : 연관된 작업 계획 고유 식별자 FK
-        private String process;             // feat : 공정명 (예: 전기 공정)
-        private Double actualProgress;      // feat : 전체 누적 진척률
-        private Double todayProgress;       // feat : 금일 입력된 진척률
-        private Long monthlyWorkPlanId;     // feat : 누적 진척률을 반영한 부모 월간 세부계획 ID
-        private Double progressIncrementPct; // feat : 금일 작업으로 월간 세부계획에 반영된 증가분
-        private Double monthlyProgressPct;   // feat : 반영 후 월간 세부계획 누적 진척률
-        private Integer actualWorkerCount;  // feat : 금일 실제 투입 인원 수
-        private String issue;               // feat : 특이사항 및 이슈
-        private LocalDate reportDate;       // feat : 공사일보 작성 일자
-        private String todayWork;           // feat : 금일 작업 완료 내용
-        private String tomorrowPlan;        // feat : 명일 작업 예정 내용
+        private Long idx;
+        private Long workPlanId;
+        private String process;
+        private Double actualProgress;
+        private Double todayProgress;
+        private Long monthlyWorkPlanId;
+        private Double progressIncrementPct;
+        private Double monthlyProgressPct;
+        private Integer actualWorkerCount;
+        private String location;
+        private String issue;
+        private LocalDate reportDate;
+        private String todayWork;
+        private String tomorrowPlan;
     }
 }

--- a/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
@@ -23,7 +23,7 @@ public interface WorkOrderRepository extends JpaRepository<WorkOrder, Long> {
                     wo.idx AS work_order_idx,
                     wo.title,
                     wo.trade_type,
-                    COALESCE(wo.instruction_content, wp.note, wp.name, '') AS work_detail,
+                    COALESCE(wo.work_detail, wo.instruction_content, wp.note, wp.name, '') AS work_detail,
                     COALESCE(wo.due_date, wp.start_date) AS work_date,
                     wp.location AS work_location,
                     wp.name AS work_plan_name,

--- a/src/main/java/org/example/dndn/workorder/WorkOrderService.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderService.java
@@ -40,6 +40,9 @@ public class WorkOrderService {
                 .tradeType(req.getTradeType())
                 .title(req.getTitle())
                 .instructionContent(req.getInstructionContent())
+                .workDetail(req.getWorkDetail())
+                .workTime(req.getWorkTime())
+                .safetyContent(req.getSafetyContent())
                 .dueDate(req.getDueDate())
                 .statusCode(req.getStatusCode())
                 .workerCount(req.getWorkerCount())
@@ -90,6 +93,9 @@ public class WorkOrderService {
                     .tradeType(order.getTradeType())
                     .title(order.getTitle())
                     .instructionContent(order.getInstructionContent())
+                    .workDetail(firstNonBlank(order.getWorkDetail(), order.getInstructionContent()))
+                    .workTime(order.getWorkTime())
+                    .safetyContent(order.getSafetyContent())
                     .dueDate(order.getDueDate())
                     .statusCode(order.getStatusCode())
                     .workerCount(order.getWorkerCount())
@@ -142,6 +148,9 @@ public class WorkOrderService {
         workOrder.setTradeType(req.getTradeType());
         workOrder.setTitle(req.getTitle());
         workOrder.setInstructionContent(req.getInstructionContent());
+        workOrder.setWorkDetail(req.getWorkDetail());
+        workOrder.setWorkTime(req.getWorkTime());
+        workOrder.setSafetyContent(req.getSafetyContent());
         workOrder.setDueDate(req.getDueDate());
         workOrder.setStatusCode(req.getStatusCode());
         workOrder.setWorkerCount(req.getWorkerCount());
@@ -211,7 +220,7 @@ public class WorkOrderService {
                 weeklyPlan.getPartner(),
                 weeklyPlan.getManager(),
                 weeklyPlan.getContact(),
-                workOrder.getInstructionContent()
+                firstNonBlank(workOrder.getWorkDetail(), workOrder.getInstructionContent())
         );
 
         //  2. 인원 정보 반영 (replaceWorkers를 사용해야 requiredCount가 자동 계산됨)

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrder.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrder.java
@@ -33,6 +33,14 @@ public class WorkOrder extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String instructionContent;
 
+    @Column(columnDefinition = "TEXT")
+    private String workDetail;
+
+    private String workTime;
+
+    @Column(columnDefinition = "TEXT")
+    private String safetyContent;
+
     private LocalDate dueDate;
     private String statusCode;
 

--- a/src/main/java/org/example/dndn/workorder/model/WorkOrderDto.java
+++ b/src/main/java/org/example/dndn/workorder/model/WorkOrderDto.java
@@ -16,6 +16,9 @@ public class WorkOrderDto {
         private String tradeType;
         private String title;
         private String instructionContent;
+        private String workDetail;
+        private String workTime;
+        private String safetyContent;
         private LocalDate dueDate;
         private String statusCode;
         private Integer workerCount;
@@ -33,6 +36,9 @@ public class WorkOrderDto {
         private String tradeType;
         private String title;
         private String instructionContent;
+        private String workDetail;
+        private String workTime;
+        private String safetyContent;
         private LocalDate dueDate;
         private String statusCode;
         private Integer workerCount;


### PR DESCRIPTION
## Summary

공정 분석 화면에서 사용하는 지연 위험 분석, AI 일정 추천, 일정 변경 요청/승인/반영 흐름을 지원하기 위한 백엔드 기능을 추가했습니다.

## Changes

- 공정 분석 지연 판단 로직 개선
  - 공사일보에 기록된 월간 세부계획 실제 진척률을 기준으로 실적 계산
  - 당일 공사일보가 제출되지 않은 작업은 당일 지연 위험 판단에서 제외
  - 마일스톤 공정은 공종별 진척률 응답에서 제외
  - 최신 공사일보 기준으로 분석 기준일/실적 출처 제공

- AI 일정 추천 API 추가
  - AI 추천 요청 생성 및 조회 API 추가
  - 지연 위험 작업의 하위 세부일정 기준으로 변경 후보 생성
  - 추천 결과에 세부일정별 인력, 작업시간, 공수, 목표 진척률 변경 데이터 포함
  - OpenAI 미설정/실패 시에도 기본 추천안으로 동작 가능하도록 구성

- 일정 변경 반영 데이터 보강
  - 변경 요청에 세부일정별 변경 내역 저장
  - 승인 후 공정표 반영 시 대상 WorkPlan의 작업명, 인력, 작업시간, 비고 변경 반영
  - 변경 이력에서 AI 추천 반영 여부와 상세 변경 데이터 조회 가능

- 공사일보 데이터 보강
  - 공사일보 위치 저장 및 응답 필드 추가
  - 기존 위치가 없는 공사일보는 연결된 작업계획 위치로 fallback
  - 월간 세부계획 진척률/금일 증가분 응답 보강

- 작업지시서 데이터 구조 개선
  - 작업 상세, 작업시간, 안전 유의사항 필드 분리
  - 작업지시서 승인 시 작업계획에 변경된 작업 상세/시간 정보 반영
  - 작업지시서 조회 시 기존 note 기반 데이터와 신규 필드 호환 처리