### PR TITLE
[Feat] 현장 및 공종 기반 권한 스코프 적용

### DIFF
--- a/scripts/SeedMayJuneMonthlyPlans.java
+++ b/scripts/SeedMayJuneMonthlyPlans.java
@@ -1,0 +1,695 @@
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringJoiner;
+
+public class SeedMayJuneMonthlyPlans {
+
+    private static final long PROJECT_ID = 5L;
+    private static final String MARKER = "[DEMO_MONTHLY_20260506]";
+    private static final LocalDate CUTOFF = LocalDate.of(2026, 5, 8);
+    private static final Timestamp NOW = Timestamp.valueOf(LocalDateTime.now());
+
+    public static void main(String[] args) throws Exception {
+        Map<String, String> env = loadEnv(Path.of(".env"));
+        Class.forName("org.mariadb.jdbc.Driver");
+
+        try (Connection connection = DriverManager.getConnection(
+                required(env, "DB_URL"),
+                required(env, "DB_USER"),
+                required(env, "DB_PASS")
+        )) {
+            connection.setAutoCommit(false);
+
+            try {
+                Project project = loadProject(connection);
+                deleteExistingMarkerData(connection);
+
+                Stats stats = new Stats();
+                for (PlanSpec spec : specs()) {
+                    seedSpec(connection, project, spec, stats);
+                }
+
+                connection.commit();
+                System.out.println("May/June monthly seed completed");
+                System.out.println("projectId=" + PROJECT_ID);
+                System.out.println("marker=" + MARKER);
+                System.out.println("monthlyPlans=" + stats.monthlyPlans);
+                System.out.println("weeklyPlans=" + stats.weeklyPlans);
+                System.out.println("workOrders=" + stats.workOrders);
+                System.out.println("dailyReports=" + stats.dailyReports);
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
+            }
+        }
+    }
+
+    private static void seedSpec(Connection connection, Project project, PlanSpec spec, Stats stats) throws Exception {
+        TradeProcess process = findTradeProcess(connection, spec.processName);
+        if (process == null) {
+            throw new IllegalStateException("Trade process not found: " + spec.processName);
+        }
+
+        LocalDate start = max(spec.startDate, process.plannedStart);
+        LocalDate end = min(spec.endDate, process.plannedEnd);
+        if (start.isAfter(end)) {
+            throw new IllegalStateException(
+                    "Spec is outside master schedule: " + spec.name + " / " + process.processName
+            );
+        }
+
+        Long rootMonthlyId = findRootMonthlyPlanId(connection, process.id);
+        if (rootMonthlyId == null) {
+            throw new IllegalStateException("Root monthly plan not found for trade_process_id=" + process.id);
+        }
+
+        WorkTemplate template = WorkTemplate.from(spec.trade);
+        boolean started = !start.isAfter(CUTOFF);
+        double monthProgress = started ? plannedPct(start, end, min(CUTOFF, end)) : 0.0;
+
+        long monthlyId = insertWorkPlan(
+                connection,
+                process.id,
+                rootMonthlyId,
+                "MONTHLY",
+                spec.name,
+                spec.trade,
+                spec.location,
+                start,
+                end,
+                started ? start : null,
+                monthProgress,
+                started ? "IN_PROGRESS" : "PLANNED",
+                spec.partner,
+                spec.manager,
+                spec.contact,
+                spec.requiredCount,
+                MARKER + " MONTH " + spec.key
+        );
+        insertResources(connection, monthlyId, spec.trade, spec.requiredCount, template);
+        stats.monthlyPlans++;
+
+        List<DateRange> weekRanges = splitInTwo(start, end);
+        int weekNo = 1;
+        double previousMonthProgress = 0.0;
+        for (DateRange week : weekRanges) {
+            boolean weekStarted = !week.start.isAfter(CUTOFF);
+            double weeklyProgress = weekStarted ? plannedPct(week.start, week.end, min(CUTOFF, week.end)) : 0.0;
+            String status = weekStarted ? "IN_PROGRESS" : "PLANNED";
+
+            long weeklyId = insertWorkPlan(
+                    connection,
+                    process.id,
+                    monthlyId,
+                    "WEEKLY",
+                    spec.name + " (" + weekNo + "/2주차)",
+                    spec.trade,
+                    spec.location,
+                    week.start,
+                    week.end,
+                    weekStarted ? week.start : null,
+                    weeklyProgress,
+                    status,
+                    spec.partner,
+                    spec.manager,
+                    spec.contact,
+                    spec.requiredCount,
+                    MARKER + " WEEK " + spec.key + "-" + weekNo + " / 작업시간: 08:00 ~ 17:00"
+            );
+            insertResources(connection, weeklyId, spec.trade, spec.requiredCount, template);
+            stats.weeklyPlans++;
+
+            String orderStatus = week.end.isBefore(CUTOFF) || week.end.isEqual(CUTOFF)
+                    ? "COMPLETED"
+                    : weekStarted ? "IN_PROGRESS" : "PLANNED";
+            long workOrderId = insertWorkOrder(
+                    connection,
+                    weeklyId,
+                    spec,
+                    week.end,
+                    orderStatus
+            );
+            insertWorkOrderEquipments(connection, workOrderId, spec.trade, template);
+            stats.workOrders++;
+
+            if (weekStarted) {
+                LocalDate reportDate = min(CUTOFF, week.end);
+                double currentMonthProgress = plannedPct(start, end, reportDate);
+                double increment = Math.max(0.0, roundPct(currentMonthProgress - previousMonthProgress));
+                insertDailyReport(
+                        connection,
+                        weeklyId,
+                        monthlyId,
+                        reportDate,
+                        currentMonthProgress,
+                        increment,
+                        spec.requiredCount,
+                        spec.location,
+                        spec.name + " 계획 물량 정상 진행",
+                        nextPlanText(spec.name, reportDate, end)
+                );
+                previousMonthProgress = currentMonthProgress;
+                stats.dailyReports++;
+            }
+
+            weekNo++;
+        }
+    }
+
+    private static long insertWorkPlan(
+            Connection connection,
+            long tradeProcessId,
+            Long parentWorkPlanId,
+            String planType,
+            String name,
+            String trade,
+            String location,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalDate actualStart,
+            double progress,
+            String status,
+            String partner,
+            String manager,
+            String contact,
+            int requiredCount,
+            String note
+    ) throws Exception {
+        String sql = """
+                INSERT INTO work_plan (
+                    created_at, updated_at, actual_progress_pct, actual_start, contact,
+                    end_date, location, manager, name, note, partner, plan_type,
+                    required_count, start_date, status, trade, parent_work_plan_id, trade_process_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            ps.setBigDecimal(3, BigDecimal.valueOf(progress).setScale(2, RoundingMode.HALF_UP));
+            setDate(ps, 4, actualStart);
+            ps.setString(5, contact);
+            setDate(ps, 6, endDate);
+            ps.setString(7, location);
+            ps.setString(8, manager);
+            ps.setString(9, name);
+            ps.setString(10, note);
+            ps.setString(11, partner);
+            ps.setString(12, planType);
+            ps.setInt(13, requiredCount);
+            setDate(ps, 14, startDate);
+            ps.setString(15, status);
+            ps.setString(16, trade);
+            if (parentWorkPlanId == null) {
+                ps.setNull(17, java.sql.Types.BIGINT);
+            } else {
+                ps.setLong(17, parentWorkPlanId);
+            }
+            ps.setLong(18, tradeProcessId);
+            ps.executeUpdate();
+
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
+        }
+
+        throw new IllegalStateException("Failed to insert work_plan: " + name);
+    }
+
+    private static long insertWorkOrder(Connection connection, long weeklyId, PlanSpec spec, LocalDate dueDate, String status)
+            throws Exception {
+        String sql = """
+                INSERT INTO work_order (
+                    created_at, updated_at, due_date, instruction_content, is_deleted,
+                    partner_company_idx, safety_content, site_idx, status_code, title,
+                    trade_type, work_detail, work_plan_id, work_time, worker_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            setDate(ps, 3, dueDate);
+            ps.setString(4, spec.name + " 세부 작업 지시");
+            ps.setBoolean(5, false);
+            ps.setNull(6, java.sql.Types.BIGINT);
+            ps.setString(7, "안전모, 안전대 체결 필수 및 작업 전 TBM");
+            ps.setLong(8, PROJECT_ID);
+            ps.setString(9, status);
+            ps.setString(10, spec.name + " 작업지시서");
+            ps.setString(11, spec.trade);
+            ps.setString(12, "도면 및 시방서 기준 시공, 구간별 품질 확인, 작업 종료 후 정리정돈");
+            ps.setLong(13, weeklyId);
+            ps.setString(14, "08:00 ~ 17:00");
+            ps.setInt(15, spec.requiredCount);
+            ps.executeUpdate();
+
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
+        }
+
+        throw new IllegalStateException("Failed to insert work_order: " + spec.name);
+    }
+
+    private static void insertDailyReport(
+            Connection connection,
+            long weeklyId,
+            long monthlyId,
+            LocalDate reportDate,
+            double progress,
+            double increment,
+            int workerCount,
+            String location,
+            String todayWork,
+            String tomorrowPlan
+    ) throws Exception {
+        String sql = """
+                INSERT INTO daily_report (
+                    created_at, updated_at, actual_progress, actual_worker_count, issue,
+                    location, monthly_progress_pct, progress_increment_pct, report_date,
+                    today_progress, today_work, tomorrow_plan, monthly_work_plan_idx, work_plan_idx
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            ps.setDouble(3, progress);
+            ps.setInt(4, workerCount);
+            ps.setString(5, "정상 진행");
+            ps.setString(6, location);
+            ps.setDouble(7, progress);
+            ps.setDouble(8, increment);
+            setDate(ps, 9, reportDate);
+            ps.setDouble(10, 100.0);
+            ps.setString(11, todayWork);
+            ps.setString(12, tomorrowPlan);
+            ps.setLong(13, monthlyId);
+            ps.setLong(14, weeklyId);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void insertResources(
+            Connection connection,
+            long workPlanId,
+            String trade,
+            int workerCount,
+            WorkTemplate template
+    ) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement("""
+                INSERT INTO work_plan_worker (created_at, updated_at, count, trade, work_plan_idx)
+                VALUES (?, ?, ?, ?, ?)
+                """)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            ps.setInt(3, workerCount);
+            ps.setString(4, workerTrade(trade));
+            ps.setLong(5, workPlanId);
+            ps.executeUpdate();
+        }
+
+        try (PreparedStatement ps = connection.prepareStatement("""
+                INSERT INTO work_plan_equipment (created_at, updated_at, count, type, work_plan_idx)
+                VALUES (?, ?, ?, ?, ?)
+                """)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            ps.setInt(3, template.equipmentCount);
+            ps.setString(4, template.equipmentType);
+            ps.setLong(5, workPlanId);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void insertWorkOrderEquipments(Connection connection, long workOrderId, String trade, WorkTemplate template)
+            throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement("""
+                INSERT INTO work_order_equipment (
+                    created_at, updated_at, equipment_count, equipment_name, gate_idx, is_deleted, work_order_idx
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """)) {
+            ps.setTimestamp(1, NOW);
+            ps.setTimestamp(2, NOW);
+            ps.setInt(3, template.equipmentCount);
+            ps.setString(4, template.equipmentType);
+            ps.setInt(5, 1);
+            ps.setBoolean(6, false);
+            ps.setLong(7, workOrderId);
+            ps.executeUpdate();
+        }
+    }
+
+    private static Project loadProject(Connection connection) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement("SELECT idx, location FROM project WHERE idx = ?")) {
+            ps.setLong(1, PROJECT_ID);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new Project(rs.getLong("idx"), rs.getString("location"));
+                }
+            }
+        }
+        throw new IllegalStateException("Project not found: " + PROJECT_ID);
+    }
+
+    private static TradeProcess findTradeProcess(Connection connection, String processName) throws Exception {
+        String sql = """
+                SELECT tp.idx, tp.process_name, tp.planned_start, tp.planned_end
+                FROM trade_process tp
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND tp.process_name = ?
+                  AND (tp.is_milestone IS NULL OR tp.is_milestone = false)
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, PROJECT_ID);
+            ps.setString(2, processName);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return new TradeProcess(
+                            rs.getLong("idx"),
+                            rs.getString("process_name"),
+                            rs.getDate("planned_start").toLocalDate(),
+                            rs.getDate("planned_end").toLocalDate()
+                    );
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Long findRootMonthlyPlanId(Connection connection, long tradeProcessId) throws Exception {
+        String sql = """
+                SELECT idx
+                FROM work_plan
+                WHERE trade_process_id = ?
+                  AND plan_type = 'MONTHLY'
+                  AND parent_work_plan_id IS NULL
+                ORDER BY CASE WHEN note LIKE '[DEMO_PROGRESS_20260508]%' THEN 0 ELSE 1 END, idx
+                LIMIT 1
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, tradeProcessId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getLong("idx");
+                }
+            }
+        }
+        return null;
+    }
+
+    private static void deleteExistingMarkerData(Connection connection) throws Exception {
+        List<Long> planIds = markerPlanIds(connection);
+        if (planIds.isEmpty()) {
+            return;
+        }
+
+        String inClause = inClause(planIds.size());
+
+        executeUpdate(connection,
+                "DELETE FROM daily_report WHERE work_plan_idx IN (" + inClause + ") OR monthly_work_plan_idx IN (" + inClause + ")",
+                doubled(planIds));
+        executeUpdate(connection,
+                "DELETE FROM work_order_equipment WHERE work_order_idx IN (SELECT idx FROM work_order WHERE work_plan_id IN (" + inClause + "))",
+                planIds);
+        executeUpdate(connection,
+                "DELETE FROM work_order WHERE work_plan_id IN (" + inClause + ")",
+                planIds);
+        executeUpdate(connection,
+                "DELETE FROM work_plan_worker WHERE work_plan_idx IN (" + inClause + ")",
+                planIds);
+        executeUpdate(connection,
+                "DELETE FROM work_plan_equipment WHERE work_plan_idx IN (" + inClause + ")",
+                planIds);
+        executeUpdate(connection,
+                "DELETE FROM work_plan WHERE idx IN (" + inClause + ") AND plan_type = 'WEEKLY'",
+                planIds);
+        executeUpdate(connection,
+                "DELETE FROM work_plan WHERE idx IN (" + inClause + ") AND plan_type = 'MONTHLY'",
+                planIds);
+    }
+
+    private static List<Long> markerPlanIds(Connection connection) throws Exception {
+        String sql = """
+                SELECT wp.idx
+                FROM work_plan wp
+                JOIN trade_process tp ON tp.idx = wp.trade_process_id
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND wp.note LIKE ?
+                """;
+        List<Long> ids = new ArrayList<>();
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, PROJECT_ID);
+            ps.setString(2, MARKER + "%");
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ids.add(rs.getLong(1));
+                }
+            }
+        }
+        return ids;
+    }
+
+    private static void executeUpdate(Connection connection, String sql, List<Long> values) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            int index = 1;
+            for (Long value : values) {
+                ps.setLong(index++, value);
+            }
+            ps.executeUpdate();
+        }
+    }
+
+    private static List<Long> doubled(List<Long> values) {
+        List<Long> doubled = new ArrayList<>(values.size() * 2);
+        doubled.addAll(values);
+        doubled.addAll(values);
+        return doubled;
+    }
+
+    private static String inClause(int size) {
+        StringJoiner joiner = new StringJoiner(",");
+        for (int i = 0; i < size; i++) {
+            joiner.add("?");
+        }
+        return joiner.toString();
+    }
+
+    private static List<DateRange> splitInTwo(LocalDate start, LocalDate end) {
+        long days = ChronoUnit.DAYS.between(start, end) + 1;
+        long firstDays = Math.max(1, (long) Math.ceil(days / 2.0));
+        LocalDate firstEnd = min(start.plusDays(firstDays - 1), end);
+
+        List<DateRange> ranges = new ArrayList<>();
+        ranges.add(new DateRange(start, firstEnd));
+        if (firstEnd.isBefore(end)) {
+            ranges.add(new DateRange(firstEnd.plusDays(1), end));
+        }
+        return ranges;
+    }
+
+    private static double plannedPct(LocalDate start, LocalDate end, LocalDate today) {
+        if (today.isBefore(start)) return 0.0;
+        if (today.isAfter(end)) return 100.0;
+
+        long totalDays = ChronoUnit.DAYS.between(start, end) + 1;
+        long elapsedDays = ChronoUnit.DAYS.between(start, today) + 1;
+        return roundPct(elapsedDays * 100.0 / totalDays);
+    }
+
+    private static double roundPct(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    private static LocalDate min(LocalDate left, LocalDate right) {
+        return left.isBefore(right) ? left : right;
+    }
+
+    private static LocalDate max(LocalDate left, LocalDate right) {
+        return left.isAfter(right) ? left : right;
+    }
+
+    private static void setDate(PreparedStatement ps, int index, LocalDate date) throws Exception {
+        if (date == null) {
+            ps.setNull(index, java.sql.Types.DATE);
+        } else {
+            ps.setDate(index, Date.valueOf(date));
+        }
+    }
+
+    private static String workerTrade(String trade) {
+        return switch (trade) {
+            case "PAINT" -> "PAINTER";
+            case "ELECTRIC" -> "ELECTRICIAN";
+            case "MASONRY" -> "MASON";
+            case "WATERPROOF" -> "WATERPROOFER";
+            case "PLASTER" -> "PLASTERER";
+            case "TILE" -> "TILER";
+            case "FRAME" -> "REBAR";
+            case "FACILITY" -> "PLUMBER";
+            default -> "COMMON";
+        };
+    }
+
+    private static String nextPlanText(String name, LocalDate reportDate, LocalDate end) {
+        if (reportDate.isBefore(end)) {
+            return name + " 잔여 구간 계획 물량 시공";
+        }
+        return name + " 후속 공정 준비 및 품질 점검";
+    }
+
+    private static Map<String, String> loadEnv(Path path) throws Exception {
+        Map<String, String> env = new LinkedHashMap<>();
+        for (String rawLine : Files.readAllLines(path)) {
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.startsWith("#") || !line.contains("=")) {
+                continue;
+            }
+            int pos = line.indexOf('=');
+            env.put(line.substring(0, pos), stripQuotes(line.substring(pos + 1)));
+        }
+        return env;
+    }
+
+    private static String required(Map<String, String> env, String key) {
+        String value = env.get(key);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing .env value: " + key);
+        }
+        return value;
+    }
+
+    private static String stripQuotes(String value) {
+        String trimmed = value.trim();
+        if ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+                || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    private static List<PlanSpec> specs() {
+        List<PlanSpec> specs = new ArrayList<>();
+
+        specs.add(new PlanSpec("MAY-01", "타워크레인·리프트 설치/해체", "5월 타워크레인 운용", "ETC", "현장 전구역", "이현장", "010-1111-2222", "한화건설", 2, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-02", "지상 저층부 골조", "5월 저층부 골조 마감", "FRAME", "101~104동 저층부", "박골조", "010-2222-3333", "(주)대한골조", 18, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-03", "지상 중층부 골조", "5월 중층부 골조", "FRAME", "101~104동 중층부", "박골조", "010-2222-3333", "(주)대한골조", 18, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-04", "조적", "5월 조적 공정", "MASONRY", "101동 저층부", "김조적", "010-3333-4444", "(주)세움조적", 10, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-05", "미장", "5월 미장 공정", "PLASTER", "101동 저층부 및 공용부", "이미장", "010-4444-5555", "(주)대성미장", 10, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-06", "단열", "5월 단열 공정", "ETC", "101~102동 외벽", "최단열", "010-5555-6666", "(주)그린단열", 8, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-07", "수변전·간선 전기공사", "5월 수변전·간선", "ELECTRIC", "지하 2층 전기실", "오전기", "010-6666-7777", "(주)광명전력", 10, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-08", "세대 전기·조명 공사", "5월 세대 전기·조명", "ELECTRIC", "전 세대 내부", "오전기", "010-6666-7777", "(주)광명전력", 20, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-09", "통신·홈네트워크·CCTV", "5월 통신·네트워크", "ELECTRIC", "전 세대 내부", "윤통신", "010-7777-8888", "(주)제일통신", 10, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-10", "소방전기·비상방송", "5월 소방전기", "ELECTRIC", "공용부", "정소방", "010-8888-9999", "(주)안전소방", 8, "2026-05-01", "2026-05-31"));
+        specs.add(new PlanSpec("MAY-11", "부대토목·우오수·상하수도", "5월 부대토목 공사", "LANDSCAPE", "단지 외부", "유토목", "010-9999-0000", "(주)대지건설", 12, "2026-05-01", "2026-05-31"));
+
+        specs.add(new PlanSpec("JUN-01", "타워크레인·리프트 설치/해체", "6월 타워크레인 운용", "ETC", "현장 전구역", "이현장", "010-1111-2222", "한화건설", 2, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-02", "지상 중층부 골조", "6월 중층부 골조", "FRAME", "101~104동 중층부", "박골조", "010-2222-3333", "(주)대한골조", 18, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-03", "조적", "6월 조적 공정", "MASONRY", "101~102동 중층부", "김조적", "010-3333-4444", "(주)세움조적", 12, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-04", "미장", "6월 미장 공정", "PLASTER", "101~102동 중층부 및 공용부", "이미장", "010-4444-5555", "(주)대성미장", 12, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-05", "방수", "6월 방수 공정", "WATERPROOF", "지하 및 옥상 방수 구간", "한방수", "010-5555-1111", "(주)우진방수", 8, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-06", "창호", "6월 창호 공정", "ETC", "101~104동 외창호", "임창호", "010-5555-2222", "(주)신성창호", 10, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-07", "타일", "6월 타일 공정", "TILE", "101동 욕실 및 공용부", "서타일", "010-5555-3333", "(주)바른타일", 10, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-08", "도배", "6월 도배 공정", "ETC", "101동 저층부", "이도배", "010-2222-3333", "(주)바른벽지", 10, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-09", "수변전·간선 전기공사", "6월 수변전·간선", "ELECTRIC", "지하 2층 전기실", "오전기", "010-6666-7777", "(주)광명전력", 8, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-10", "세대 전기·조명 공사", "6월 세대 전기·조명", "ELECTRIC", "전 세대 내부", "오전기", "010-6666-7777", "(주)광명전력", 20, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-11", "통신·홈네트워크·CCTV", "6월 통신·네트워크", "ELECTRIC", "전 세대 내부", "윤통신", "010-7777-8888", "(주)제일통신", 12, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-12", "소방전기·비상방송", "6월 소방전기", "ELECTRIC", "공용부", "정소방", "010-8888-9999", "(주)안전소방", 8, "2026-06-01", "2026-06-30"));
+        specs.add(new PlanSpec("JUN-13", "부대토목·우오수·상하수도", "6월 부대토목 공사", "LANDSCAPE", "단지 외부", "유토목", "010-9999-0000", "(주)대지건설", 15, "2026-06-01", "2026-06-30"));
+
+        return specs;
+    }
+
+    private record Project(long id, String location) {
+    }
+
+    private record TradeProcess(long id, String processName, LocalDate plannedStart, LocalDate plannedEnd) {
+    }
+
+    private record DateRange(LocalDate start, LocalDate end) {
+    }
+
+    private static class PlanSpec {
+        final String key;
+        final String processName;
+        final String name;
+        final String trade;
+        final String location;
+        final String manager;
+        final String contact;
+        final String partner;
+        final int requiredCount;
+        final LocalDate startDate;
+        final LocalDate endDate;
+
+        PlanSpec(
+                String key,
+                String processName,
+                String name,
+                String trade,
+                String location,
+                String manager,
+                String contact,
+                String partner,
+                int requiredCount,
+                String startDate,
+                String endDate
+        ) {
+            this.key = key;
+            this.processName = processName;
+            this.name = name;
+            this.trade = trade;
+            this.location = location;
+            this.manager = manager;
+            this.contact = contact;
+            this.partner = partner;
+            this.requiredCount = requiredCount;
+            this.startDate = LocalDate.parse(startDate);
+            this.endDate = LocalDate.parse(endDate);
+        }
+    }
+
+    private record WorkTemplate(String equipmentType, int equipmentCount) {
+        static WorkTemplate from(String trade) {
+            return switch (trade) {
+                case "LANDSCAPE" -> new WorkTemplate("DUMP_TRUCK", 2);
+                case "PAINT" -> new WorkTemplate("AERIAL_WORK_PLATFORM", 1);
+                case "PAVEMENT" -> new WorkTemplate("ASPHALT_PAVER", 1);
+                case "FRAME" -> new WorkTemplate("TOWER_CRANE", 1);
+                case "ELECTRIC" -> new WorkTemplate("AERIAL_WORK_PLATFORM", 1);
+                case "WATERPROOF" -> new WorkTemplate("OTHER", 1);
+                default -> new WorkTemplate("OTHER", 1);
+            };
+        }
+    }
+
+    private static class Stats {
+        int monthlyPlans;
+        int weeklyPlans;
+        int workOrders;
+        int dailyReports;
+    }
+}

--- a/scripts/SeedRealisticProgressData.java
+++ b/scripts/SeedRealisticProgressData.java
@@ -1,0 +1,830 @@
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class SeedRealisticProgressData {
+
+    private static final String MARKER = "[DEMO_PROGRESS_20260508]";
+    private static final long DEFAULT_PROJECT_ID = 5L;
+    private static final LocalDate DEFAULT_CUTOFF = LocalDate.of(2026, 5, 8);
+    private static final LocalDateTime NOW = LocalDateTime.now();
+    private static final Timestamp NOW_TS = Timestamp.valueOf(NOW);
+
+    public static void main(String[] args) throws Exception {
+        Options options = Options.parse(args);
+        Map<String, String> env = loadEnv(Path.of(".env"));
+
+        Class.forName("org.mariadb.jdbc.Driver");
+
+        try (Connection connection = DriverManager.getConnection(
+                required(env, "DB_URL"),
+                required(env, "DB_USER"),
+                required(env, "DB_PASS")
+        )) {
+            connection.setAutoCommit(false);
+
+            try {
+                Project project = loadProject(connection, options.projectId);
+                if (project == null) {
+                    throw new IllegalStateException("Project not found: " + options.projectId);
+                }
+
+                long existingWorkPlans = countProjectWorkPlans(connection, options.projectId);
+                long existingDemoPlans = countProjectDemoWorkPlans(connection, options.projectId);
+
+                if (existingDemoPlans > 0 && !options.force) {
+                    throw new IllegalStateException("Demo work plans already exist. Re-run with --force to replace them.");
+                }
+
+                if (existingWorkPlans > existingDemoPlans && !options.force) {
+                    throw new IllegalStateException("Non-demo work plans already exist. Re-run with --force only if replacing demo data is intended.");
+                }
+
+                if (options.force && existingDemoPlans > 0) {
+                    deleteDemoData(connection, options.projectId);
+                }
+
+                List<TradeProcess> processes = loadTradeProcesses(connection, options.projectId);
+                if (processes.isEmpty()) {
+                    throw new IllegalStateException("No extracted trade processes found for project: " + options.projectId);
+                }
+
+                Stats stats = new Stats();
+                for (TradeProcess process : processes) {
+                    seedProcess(connection, project, process, options.cutoff, stats);
+                }
+
+                connection.commit();
+                System.out.println("Seed completed");
+                System.out.println("projectId=" + options.projectId);
+                System.out.println("cutoff=" + options.cutoff);
+                System.out.println("tradeProcesses=" + processes.size());
+                System.out.println("yearlyPlans=" + stats.yearlyPlans);
+                System.out.println("monthlyPlans=" + stats.monthlyPlans);
+                System.out.println("weeklyPlans=" + stats.weeklyPlans);
+                System.out.println("workOrders=" + stats.workOrders);
+                System.out.println("dailyReports=" + stats.dailyReports);
+            } catch (Exception e) {
+                connection.rollback();
+                throw e;
+            }
+        }
+    }
+
+    private static void seedProcess(
+            Connection connection,
+            Project project,
+            TradeProcess process,
+            LocalDate cutoff,
+            Stats stats
+    ) throws Exception {
+        if (process.plannedStart == null || process.plannedEnd == null) {
+            stats.skippedProcesses++;
+            return;
+        }
+
+        WorkTemplate template = WorkTemplate.from(process.tradeName, process.processName);
+        String partner = nonBlank(process.partnerCompany, process.tradeName + " 협력사");
+        String manager = "전성훈";
+        String contact = "010-0000-0000";
+
+        for (int year = 2024; year <= 2026; year++) {
+            LocalDate yearStart = LocalDate.of(year, 1, 1);
+            LocalDate yearEnd = LocalDate.of(year, 12, 31);
+            LocalDate segmentStart = max(process.plannedStart, yearStart);
+            LocalDate segmentEnd = min(process.plannedEnd, yearEnd);
+
+            if (segmentStart.isAfter(segmentEnd)) {
+                continue;
+            }
+
+            boolean started = !segmentStart.isAfter(cutoff);
+            double progress = started
+                    ? plannedPct(segmentStart, segmentEnd, min(cutoff, segmentEnd))
+                    : 0.0;
+
+            long yearlyId = insertWorkPlan(
+                    connection,
+                    process.id,
+                    null,
+                    "YEARLY",
+                    process.processName + " " + year + "년 연간 실행계획",
+                    template.workTrade,
+                    project.location,
+                    segmentStart,
+                    segmentEnd,
+                    started ? segmentStart : null,
+                    progress,
+                    started ? "IN_PROGRESS" : "PLANNED",
+                    partner,
+                    manager,
+                    contact,
+                    template.workerTotal(),
+                    MARKER + " 연간 실행계획 / 기준일 " + cutoff
+            );
+            insertResources(connection, yearlyId, template);
+            stats.yearlyPlans++;
+        }
+
+        boolean processStarted = !process.plannedStart.isAfter(cutoff);
+        double monthlyProgress = processStarted
+                ? plannedPct(process.plannedStart, process.plannedEnd, min(cutoff, process.plannedEnd))
+                : 0.0;
+
+        long monthlyId = insertWorkPlan(
+                connection,
+                process.id,
+                null,
+                "MONTHLY",
+                process.processName + " 세부 실행계획",
+                template.workTrade,
+                project.location,
+                process.plannedStart,
+                process.plannedEnd,
+                processStarted ? process.plannedStart : null,
+                monthlyProgress,
+                processStarted ? "IN_PROGRESS" : "PLANNED",
+                partner,
+                manager,
+                contact,
+                template.workerTotal(),
+                MARKER + " 세부 실행계획 / 계획 대비 실적 동기화"
+        );
+        insertResources(connection, monthlyId, template);
+        stats.monthlyPlans++;
+
+        if (!processStarted) {
+            return;
+        }
+
+        LocalDate reportUntil = min(process.plannedEnd, cutoff);
+        LocalDate cursor = process.plannedStart;
+        int weekNo = 1;
+        double previousMonthlyProgress = 0.0;
+
+        while (!cursor.isAfter(reportUntil)) {
+            LocalDate weekEnd = min(cursor.plusDays(6), reportUntil);
+
+            long weeklyId = insertWorkPlan(
+                    connection,
+                    process.id,
+                    monthlyId,
+                    "WEEKLY",
+                    process.processName + " 주간 작업 " + weekNo,
+                    template.workTrade,
+                    project.location,
+                    cursor,
+                    weekEnd,
+                    cursor,
+                    100.0,
+                    "IN_PROGRESS",
+                    partner,
+                    manager,
+                    contact,
+                    template.workerTotal(),
+                    MARKER + " 주간 실행계획 / 작업시간: 08:00 ~ 17:30"
+            );
+            insertResources(connection, weeklyId, template);
+            stats.weeklyPlans++;
+
+            long workOrderId = insertWorkOrder(
+                    connection,
+                    project.id,
+                    weeklyId,
+                    process.tradeName,
+                    process.processName + " 작업지시",
+                    cursor,
+                    template.workerTotal(),
+                    "도면 및 시방 기준에 따라 " + process.processName + " 작업을 진행합니다.",
+                    "구간별 작업 전 안전점검, 작업 중 품질 확인, 작업 종료 후 정리정돈을 완료합니다.",
+                    "개인보호구 착용, 장비 유도자 배치, 작업 전 TBM 실시"
+            );
+            insertWorkOrderEquipments(connection, workOrderId, template);
+            stats.workOrders++;
+
+            LocalDate reportDate = cursor;
+            while (!reportDate.isAfter(weekEnd)) {
+                double currentProgress = plannedPct(process.plannedStart, process.plannedEnd, reportDate);
+                double increment = Math.max(0.0, roundPct(currentProgress - previousMonthlyProgress));
+                insertDailyReport(
+                        connection,
+                        weeklyId,
+                        monthlyId,
+                        reportDate,
+                        currentProgress,
+                        increment,
+                        template.workerTotal(),
+                        project.location,
+                        "정상 진행",
+                        process.processName + " 계획 물량 시공 및 품질 확인",
+                        nextPlanText(process.processName, reportDate, reportUntil)
+                );
+                previousMonthlyProgress = currentProgress;
+                stats.dailyReports++;
+                reportDate = reportDate.plusDays(1);
+            }
+
+            cursor = weekEnd.plusDays(1);
+            weekNo++;
+        }
+    }
+
+    private static long insertWorkPlan(
+            Connection connection,
+            long tradeProcessId,
+            Long parentWorkPlanId,
+            String planType,
+            String name,
+            String trade,
+            String location,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalDate actualStart,
+            double actualProgressPct,
+            String status,
+            String partner,
+            String manager,
+            String contact,
+            int requiredCount,
+            String note
+    ) throws Exception {
+        String sql = """
+                INSERT INTO work_plan (
+                    created_at, updated_at, actual_progress_pct, actual_start, contact,
+                    end_date, location, manager, name, note, partner, plan_type,
+                    required_count, start_date, status, trade, parent_work_plan_id, trade_process_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setTimestamp(1, NOW_TS);
+            ps.setTimestamp(2, NOW_TS);
+            ps.setBigDecimal(3, BigDecimal.valueOf(actualProgressPct).setScale(2, RoundingMode.HALF_UP));
+            setDate(ps, 4, actualStart);
+            ps.setString(5, contact);
+            setDate(ps, 6, endDate);
+            ps.setString(7, location);
+            ps.setString(8, manager);
+            ps.setString(9, name);
+            ps.setString(10, note);
+            ps.setString(11, partner);
+            ps.setString(12, planType);
+            ps.setInt(13, requiredCount);
+            setDate(ps, 14, startDate);
+            ps.setString(15, status);
+            ps.setString(16, trade);
+            if (parentWorkPlanId == null) {
+                ps.setNull(17, java.sql.Types.BIGINT);
+            } else {
+                ps.setLong(17, parentWorkPlanId);
+            }
+            ps.setLong(18, tradeProcessId);
+            ps.executeUpdate();
+
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
+        }
+
+        throw new IllegalStateException("Failed to insert work_plan: " + name);
+    }
+
+    private static long insertWorkOrder(
+            Connection connection,
+            long projectId,
+            long weeklyWorkPlanId,
+            String tradeName,
+            String title,
+            LocalDate dueDate,
+            int workerCount,
+            String instruction,
+            String workDetail,
+            String safetyContent
+    ) throws Exception {
+        String sql = """
+                INSERT INTO work_order (
+                    created_at, updated_at, due_date, instruction_content, is_deleted,
+                    partner_company_idx, safety_content, site_idx, status_code, title,
+                    trade_type, work_detail, work_plan_id, work_time, worker_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setTimestamp(1, NOW_TS);
+            ps.setTimestamp(2, NOW_TS);
+            setDate(ps, 3, dueDate);
+            ps.setString(4, instruction);
+            ps.setBoolean(5, false);
+            ps.setNull(6, java.sql.Types.BIGINT);
+            ps.setString(7, safetyContent);
+            ps.setLong(8, projectId);
+            ps.setString(9, "COMPLETED");
+            ps.setString(10, title);
+            ps.setString(11, tradeName);
+            ps.setString(12, workDetail);
+            ps.setLong(13, weeklyWorkPlanId);
+            ps.setString(14, "08:00 ~ 17:30");
+            ps.setInt(15, workerCount);
+            ps.executeUpdate();
+
+            try (ResultSet keys = ps.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
+        }
+
+        throw new IllegalStateException("Failed to insert work_order: " + title);
+    }
+
+    private static void insertDailyReport(
+            Connection connection,
+            long weeklyWorkPlanId,
+            long monthlyWorkPlanId,
+            LocalDate reportDate,
+            double monthlyProgressPct,
+            double progressIncrementPct,
+            int workerCount,
+            String location,
+            String issue,
+            String todayWork,
+            String tomorrowPlan
+    ) throws Exception {
+        String sql = """
+                INSERT INTO daily_report (
+                    created_at, updated_at, actual_progress, actual_worker_count, issue,
+                    location, monthly_progress_pct, progress_increment_pct, report_date,
+                    today_progress, today_work, tomorrow_plan, monthly_work_plan_idx, work_plan_idx
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """;
+
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setTimestamp(1, NOW_TS);
+            ps.setTimestamp(2, NOW_TS);
+            ps.setDouble(3, monthlyProgressPct);
+            ps.setInt(4, workerCount);
+            ps.setString(5, issue);
+            ps.setString(6, location);
+            ps.setDouble(7, monthlyProgressPct);
+            ps.setDouble(8, progressIncrementPct);
+            setDate(ps, 9, reportDate);
+            ps.setDouble(10, 100.0);
+            ps.setString(11, todayWork);
+            ps.setString(12, tomorrowPlan);
+            ps.setLong(13, monthlyWorkPlanId);
+            ps.setLong(14, weeklyWorkPlanId);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void insertResources(Connection connection, long workPlanId, WorkTemplate template) throws Exception {
+        String workerSql = """
+                INSERT INTO work_plan_worker (created_at, updated_at, count, trade, work_plan_idx)
+                VALUES (?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(workerSql)) {
+            for (Map.Entry<String, Integer> worker : template.workers.entrySet()) {
+                ps.setTimestamp(1, NOW_TS);
+                ps.setTimestamp(2, NOW_TS);
+                ps.setInt(3, worker.getValue());
+                ps.setString(4, worker.getKey());
+                ps.setLong(5, workPlanId);
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+
+        String equipmentSql = """
+                INSERT INTO work_plan_equipment (created_at, updated_at, count, type, work_plan_idx)
+                VALUES (?, ?, ?, ?, ?)
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(equipmentSql)) {
+            for (Map.Entry<String, Integer> equipment : template.equipment.entrySet()) {
+                ps.setTimestamp(1, NOW_TS);
+                ps.setTimestamp(2, NOW_TS);
+                ps.setInt(3, equipment.getValue());
+                ps.setString(4, equipment.getKey());
+                ps.setLong(5, workPlanId);
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private static void insertWorkOrderEquipments(Connection connection, long workOrderId, WorkTemplate template) throws Exception {
+        String sql = """
+                INSERT INTO work_order_equipment (
+                    created_at, updated_at, equipment_count, equipment_name, gate_idx, is_deleted, work_order_idx
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """;
+        int gate = 1;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            for (Map.Entry<String, Integer> equipment : template.equipment.entrySet()) {
+                ps.setTimestamp(1, NOW_TS);
+                ps.setTimestamp(2, NOW_TS);
+                ps.setInt(3, equipment.getValue());
+                ps.setString(4, equipment.getKey());
+                ps.setInt(5, gate++);
+                ps.setBoolean(6, false);
+                ps.setLong(7, workOrderId);
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        }
+    }
+
+    private static Project loadProject(Connection connection, long projectId) throws Exception {
+        String sql = "SELECT idx, name, location, start_date, end_date FROM project WHERE idx = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, projectId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    return null;
+                }
+                return new Project(
+                        rs.getLong("idx"),
+                        rs.getString("name"),
+                        rs.getString("location"),
+                        toLocalDate(rs.getDate("start_date")),
+                        toLocalDate(rs.getDate("end_date"))
+                );
+            }
+        }
+    }
+
+    private static List<TradeProcess> loadTradeProcesses(Connection connection, long projectId) throws Exception {
+        String sql = """
+                SELECT tp.idx, tp.trade_name, tp.process_name, tp.partner_company,
+                       tp.planned_start, tp.planned_end, tp.weight_pct
+                FROM trade_process tp
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND (tp.is_milestone IS NULL OR tp.is_milestone = false)
+                ORDER BY tp.planned_start, tp.idx
+                """;
+        List<TradeProcess> processes = new ArrayList<>();
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, projectId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    processes.add(new TradeProcess(
+                            rs.getLong("idx"),
+                            rs.getString("trade_name"),
+                            rs.getString("process_name"),
+                            rs.getString("partner_company"),
+                            toLocalDate(rs.getDate("planned_start")),
+                            toLocalDate(rs.getDate("planned_end")),
+                            rs.getDouble("weight_pct")
+                    ));
+                }
+            }
+        }
+        return processes;
+    }
+
+    private static long countProjectWorkPlans(Connection connection, long projectId) throws Exception {
+        String sql = """
+                SELECT COUNT(*)
+                FROM work_plan wp
+                JOIN trade_process tp ON tp.idx = wp.trade_process_id
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                """;
+        return count(connection, sql, projectId, null);
+    }
+
+    private static long countProjectDemoWorkPlans(Connection connection, long projectId) throws Exception {
+        String sql = """
+                SELECT COUNT(*)
+                FROM work_plan wp
+                JOIN trade_process tp ON tp.idx = wp.trade_process_id
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND wp.note LIKE ?
+                """;
+        return count(connection, sql, projectId, MARKER + "%");
+    }
+
+    private static long count(Connection connection, String sql, long projectId, String markerLike) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, projectId);
+            if (markerLike != null) {
+                ps.setString(2, markerLike);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+                return rs.getLong(1);
+            }
+        }
+    }
+
+    private static void deleteDemoData(Connection connection, long projectId) throws Exception {
+        String planSubquery = """
+                SELECT wp.idx
+                FROM work_plan wp
+                JOIN trade_process tp ON tp.idx = wp.trade_process_id
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND wp.note LIKE ?
+                """;
+
+        executeDelete(connection,
+                "DELETE FROM daily_report WHERE work_plan_idx IN (" + planSubquery + ") OR monthly_work_plan_idx IN (" + planSubquery + ")",
+                projectId, MARKER + "%", projectId, MARKER + "%");
+        executeDelete(connection,
+                "DELETE FROM work_order_equipment WHERE work_order_idx IN (SELECT wo.idx FROM work_order wo WHERE wo.work_plan_id IN (" + planSubquery + "))",
+                projectId, MARKER + "%");
+        executeDelete(connection,
+                "DELETE FROM work_order WHERE work_plan_id IN (" + planSubquery + ")",
+                projectId, MARKER + "%");
+        executeDelete(connection,
+                "DELETE FROM work_plan_worker WHERE work_plan_idx IN (" + planSubquery + ")",
+                projectId, MARKER + "%");
+        executeDelete(connection,
+                "DELETE FROM work_plan_equipment WHERE work_plan_idx IN (" + planSubquery + ")",
+                projectId, MARKER + "%");
+
+        deleteDemoPlansByType(connection, projectId, "WEEKLY");
+        deleteDemoPlansByType(connection, projectId, "MONTHLY");
+        deleteDemoPlansByType(connection, projectId, "YEARLY");
+    }
+
+    private static void deleteDemoPlansByType(Connection connection, long projectId, String planType) throws Exception {
+        String sql = """
+                DELETE wp
+                FROM work_plan wp
+                JOIN trade_process tp ON tp.idx = wp.trade_process_id
+                JOIN master_schedule ms ON ms.idx = tp.master_schedule_id
+                WHERE ms.project_id = ?
+                  AND wp.note LIKE ?
+                  AND wp.plan_type = ?
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setLong(1, projectId);
+            ps.setString(2, MARKER + "%");
+            ps.setString(3, planType);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void executeDelete(Connection connection, String sql, Object... values) throws Exception {
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            for (int i = 0; i < values.length; i++) {
+                Object value = values[i];
+                if (value instanceof Long longValue) {
+                    ps.setLong(i + 1, longValue);
+                } else {
+                    ps.setString(i + 1, String.valueOf(value));
+                }
+            }
+            ps.executeUpdate();
+        }
+    }
+
+    private static Map<String, String> loadEnv(Path path) throws Exception {
+        Map<String, String> env = new LinkedHashMap<>();
+        for (String rawLine : Files.readAllLines(path)) {
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.startsWith("#") || !line.contains("=")) {
+                continue;
+            }
+            int pos = line.indexOf('=');
+            env.put(line.substring(0, pos), stripQuotes(line.substring(pos + 1)));
+        }
+        return env;
+    }
+
+    private static String required(Map<String, String> env, String key) {
+        String value = env.get(key);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing .env value: " + key);
+        }
+        return value;
+    }
+
+    private static String stripQuotes(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if ((trimmed.startsWith("\"") && trimmed.endsWith("\""))
+                || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    private static LocalDate toLocalDate(Date date) {
+        return date == null ? null : date.toLocalDate();
+    }
+
+    private static void setDate(PreparedStatement ps, int index, LocalDate date) throws Exception {
+        if (date == null) {
+            ps.setNull(index, java.sql.Types.DATE);
+        } else {
+            ps.setDate(index, Date.valueOf(date));
+        }
+    }
+
+    private static double plannedPct(LocalDate start, LocalDate end, LocalDate today) {
+        if (start == null || end == null || today == null) {
+            return 0.0;
+        }
+        if (today.isBefore(start)) {
+            return 0.0;
+        }
+        if (today.isAfter(end)) {
+            return 100.0;
+        }
+        long totalDays = ChronoUnit.DAYS.between(start, end) + 1;
+        long elapsedDays = ChronoUnit.DAYS.between(start, today) + 1;
+        if (totalDays <= 0) {
+            return 100.0;
+        }
+        return roundPct(elapsedDays * 100.0 / totalDays);
+    }
+
+    private static double roundPct(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+
+    private static LocalDate min(LocalDate left, LocalDate right) {
+        return left.isBefore(right) ? left : right;
+    }
+
+    private static LocalDate max(LocalDate left, LocalDate right) {
+        return left.isAfter(right) ? left : right;
+    }
+
+    private static String nonBlank(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static String nextPlanText(String processName, LocalDate reportDate, LocalDate reportUntil) {
+        if (reportDate.isEqual(reportUntil)) {
+            return processName + " 후속 공정 준비 및 자재 반입 점검";
+        }
+        return processName + " 잔여 구간 계획 물량 시공";
+    }
+
+    private record Options(long projectId, LocalDate cutoff, boolean force) {
+        static Options parse(String[] args) {
+            long projectId = DEFAULT_PROJECT_ID;
+            LocalDate cutoff = DEFAULT_CUTOFF;
+            boolean force = false;
+
+            for (String arg : args) {
+                if ("--force".equals(arg)) {
+                    force = true;
+                } else if (arg.startsWith("--project-id=")) {
+                    projectId = Long.parseLong(arg.substring("--project-id=".length()));
+                } else if (arg.startsWith("--cutoff=")) {
+                    cutoff = LocalDate.parse(arg.substring("--cutoff=".length()));
+                } else if (!arg.isBlank()) {
+                    throw new IllegalArgumentException("Unknown argument: " + arg);
+                }
+            }
+
+            return new Options(projectId, cutoff, force);
+        }
+    }
+
+    private record Project(long id, String name, String location, LocalDate startDate, LocalDate endDate) {
+    }
+
+    private record TradeProcess(
+            long id,
+            String tradeName,
+            String processName,
+            String partnerCompany,
+            LocalDate plannedStart,
+            LocalDate plannedEnd,
+            double weightPct
+    ) {
+    }
+
+    private static class WorkTemplate {
+        final String workTrade;
+        final Map<String, Integer> workers;
+        final Map<String, Integer> equipment;
+
+        WorkTemplate(String workTrade, Map<String, Integer> workers, Map<String, Integer> equipment) {
+            this.workTrade = workTrade;
+            this.workers = workers;
+            this.equipment = equipment;
+        }
+
+        int workerTotal() {
+            return workers.values().stream().mapToInt(Integer::intValue).sum();
+        }
+
+        static WorkTemplate from(String tradeName, String processName) {
+            String source = ((tradeName == null ? "" : tradeName) + " " + (processName == null ? "" : processName))
+                    .toLowerCase(Locale.ROOT);
+
+            if (source.contains("토공") || source.contains("터파기") || source.contains("흙막이")) {
+                return new WorkTemplate("EARTHWORK",
+                        orderedMap("SKILLED", 4, "COMMON", 6),
+                        orderedMap("EXCAVATOR", 1, "DUMP_TRUCK", 3));
+            }
+            if (source.contains("골조") || source.contains("철근콘크리트")) {
+                return new WorkTemplate("FRAME",
+                        orderedMap("REBAR", 8, "FORMWORK", 6, "COMMON", 4),
+                        orderedMap("TOWER_CRANE", 1, "CONCRETE_PUMP_TRUCK", 1));
+            }
+            if (source.contains("전기") || source.contains("통신") || source.contains("cctv")) {
+                return new WorkTemplate("ELECTRIC",
+                        orderedMap("ELECTRICIAN", 6, "COMMON", 3),
+                        orderedMap("AERIAL_WORK_PLATFORM", 1));
+            }
+            if (source.contains("기계") || source.contains("설비") || source.contains("배관") || source.contains("소방")) {
+                return new WorkTemplate("FACILITY",
+                        orderedMap("PLUMBER", 5, "WELDER", 2, "COMMON", 3),
+                        orderedMap("CONSTRUCTION_HOIST", 1, "MOBILE_CRANE", 1));
+            }
+            if (source.contains("방수")) {
+                return new WorkTemplate("WATERPROOF",
+                        orderedMap("WATERPROOFER", 5, "COMMON", 3),
+                        orderedMap("OTHER", 1));
+            }
+            if (source.contains("조적")) {
+                return new WorkTemplate("MASONRY",
+                        orderedMap("MASON", 6, "COMMON", 3),
+                        orderedMap("CONSTRUCTION_HOIST", 1));
+            }
+            if (source.contains("미장")) {
+                return new WorkTemplate("PLASTER",
+                        orderedMap("PLASTERER", 6, "COMMON", 3),
+                        orderedMap("CONSTRUCTION_HOIST", 1));
+            }
+            if (source.contains("도장")) {
+                return new WorkTemplate("PAINT",
+                        orderedMap("PAINTER", 6, "COMMON", 2),
+                        orderedMap("AERIAL_WORK_PLATFORM", 1));
+            }
+            if (source.contains("타일")) {
+                return new WorkTemplate("TILE",
+                        orderedMap("TILER", 6, "COMMON", 2),
+                        orderedMap("CONSTRUCTION_HOIST", 1));
+            }
+            if (source.contains("조경")) {
+                return new WorkTemplate("LANDSCAPE",
+                        orderedMap("SKILLED", 3, "COMMON", 5),
+                        orderedMap("FORKLIFT", 1, "WATER_TRUCK", 1));
+            }
+            if (source.contains("포장")) {
+                return new WorkTemplate("PAVEMENT",
+                        orderedMap("SKILLED", 4, "COMMON", 4),
+                        orderedMap("ROAD_ROLLER", 1, "WATER_TRUCK", 1));
+            }
+            if (source.contains("기초") || source.contains("파일") || source.contains("지반")) {
+                return new WorkTemplate("REBAR",
+                        orderedMap("REBAR", 5, "FORMWORK", 4, "COMMON", 4),
+                        orderedMap("PILE_DRIVER", 1, "CONCRETE_PUMP_TRUCK", 1));
+            }
+            if (source.contains("가설") || source.contains("크레인") || source.contains("리프트")) {
+                return new WorkTemplate("ETC",
+                        orderedMap("SKILLED", 4, "COMMON", 5),
+                        orderedMap("TOWER_CRANE", 1, "CONSTRUCTION_HOIST", 1));
+            }
+            return new WorkTemplate("ETC",
+                    orderedMap("SKILLED", 3, "COMMON", 5),
+                    orderedMap("FORKLIFT", 1));
+        }
+    }
+
+    private static Map<String, Integer> orderedMap(Object... values) {
+        Map<String, Integer> map = new LinkedHashMap<>();
+        for (int i = 0; i < values.length; i += 2) {
+            map.put((String) values[i], (Integer) values[i + 1]);
+        }
+        return map;
+    }
+
+    private static class Stats {
+        int yearlyPlans;
+        int monthlyPlans;
+        int weeklyPlans;
+        int workOrders;
+        int dailyReports;
+        int skippedProcesses;
+    }
+}

--- a/src/main/java/org/example/dndn/analysis/AnalysisService.java
+++ b/src/main/java/org/example/dndn/analysis/AnalysisService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.analysis;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.analysis.model.AnalysisDto;
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.example.dndn.project.repository.TradeProcessRepository;
@@ -36,6 +37,7 @@ public class AnalysisService {
     private final TradeProcessRepository tradeProcessRepository;
     private final WorkPlanRepository workPlanRepository;
     private final DailyReportRepository dailyReportRepository;
+    private final AuthAccessService authAccessService;
 
     // ?????????????????????????????????????????????
     // 1. 怨듭젙 吏꾩쿃瑜?鍮꾧탳
@@ -44,11 +46,13 @@ public class AnalysisService {
     // ?????????????????????????????????????????????
 
     public List<AnalysisDto.ProcessProgressRes> getProgressList(Long projectId) {
+        authAccessService.assertProjectAccess(projectId);
         LocalDate today = LocalDate.now(ANALYSIS_ZONE);
 
         return tradeProcessRepository
                 .findAllByMasterSchedule_Project_Idx(projectId)
                 .stream()
+                .filter(authAccessService::canAccessTradeProcess)
                 .filter(tp -> !isMilestoneProcess(tp))
                 .map(tp -> buildProgressRes(tp, today))
                 .toList();
@@ -114,13 +118,15 @@ public class AnalysisService {
     // ?????????????????????????????????????????????
 
     public List<AnalysisDto.DelayRiskDetailRes> getDelayRiskTasks(Long projectId, Long tradeProcessId) {
+        authAccessService.assertProjectAccess(projectId);
         LocalDate today = LocalDate.now(ANALYSIS_ZONE);
 
         return workPlanRepository
                 .findAllByTradeProcess_MasterSchedule_Project_Idx(projectId)
                 .stream()
                 // 101??湲곗큹 肄섑겕由ы듃 ???媛숈? ?몃? ?묒뾽
-                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .filter(authAccessService::canAccessWorkPlan)
+                .filter(this::isRootMonthlyPlan)
 
                 // ?뱀젙 怨듭젙 ?좏깮 ???대떦 怨듭젙???몃? ?묒뾽留?議고쉶
                 .filter(wp -> tradeProcessId == null
@@ -229,7 +235,9 @@ public class AnalysisService {
             ActualProgressSnapshot actualProgress,
             LocalDate today
     ) {
-        if (hasDailyReportOn(actualProgress, today)) return today;
+        if (actualProgress != null && actualProgress.reportDate() != null) {
+            return actualProgress.reportDate();
+        }
 
         LocalTime workEndTime = resolveTradeProcessWorkEndTime(tradeProcessId, today);
         if (LocalTime.now(ANALYSIS_ZONE).isBefore(workEndTime)) {
@@ -244,7 +252,9 @@ public class AnalysisService {
             ActualProgressSnapshot actualProgress,
             LocalDate today
     ) {
-        if (hasDailyReportOn(actualProgress, today)) return today;
+        if (actualProgress != null && actualProgress.reportDate() != null) {
+            return actualProgress.reportDate();
+        }
 
         LocalTime workEndTime = resolveMonthlyPlanWorkEndTime(monthlyPlan, today);
         if (LocalTime.now(ANALYSIS_ZONE).isBefore(workEndTime)) {
@@ -273,7 +283,7 @@ public class AnalysisService {
 
         return workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId)
                 .stream()
-                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .filter(this::isRootMonthlyPlan)
                 .map(monthlyPlan -> resolveMonthlyPlanWorkEndTime(monthlyPlan, date))
                 .max(LocalTime::compareTo)
                 .orElse(DEFAULT_WORK_END_TIME);
@@ -328,7 +338,7 @@ public class AnalysisService {
         if (plans.isEmpty()) return ActualProgressSnapshot.none();
 
         List<ActualProgressSnapshot> snapshots = plans.stream()
-                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .filter(this::isRootMonthlyPlan)
                 .map(wp -> getActualProgressByMonthlyPlan(wp, today))
                 .filter(ActualProgressSnapshot::hasDailyReport)
                 .toList();
@@ -391,7 +401,7 @@ public class AnalysisService {
     private int calcActualWorkersByTradeProcess(Long tradeProcessId, LocalDate today) {
         return workPlanRepository.findAllByTradeProcess_Idx(tradeProcessId)
                 .stream()
-                .filter(wp -> wp.getPlanType() == PlanType.MONTHLY)
+                .filter(this::isRootMonthlyPlan)
                 .flatMap(parent -> workPlanRepository.findAllByParentWorkPlan_Idx(parent.getIdx()).stream())
                 .mapToInt(child -> getLatestActualWorkersByWorkPlan(child.getIdx(), today))
                 .sum();
@@ -434,6 +444,12 @@ public class AnalysisService {
     // ?????????????????????????????????????????????
     // 5. 怨꾪쉷 吏꾩쿃瑜?/ ?덉긽 醫낅즺??
     // ?????????????????????????????????????????????
+
+    private boolean isRootMonthlyPlan(WorkPlan workPlan) {
+        return workPlan != null
+                && workPlan.getPlanType() == PlanType.MONTHLY
+                && workPlan.getParentWorkPlan() == null;
+    }
 
     private double calcPlannedPct(LocalDate start, LocalDate end, LocalDate today) {
         if (start == null || end == null) return 0.0;

--- a/src/main/java/org/example/dndn/analysis/ScheduleChangeRepository.java
+++ b/src/main/java/org/example/dndn/analysis/ScheduleChangeRepository.java
@@ -3,7 +3,11 @@ package org.example.dndn.analysis;
 import org.example.dndn.analysis.model.ScheduleChange;
 import org.example.dndn.analysis.model.ScheduleChangeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ScheduleChangeRepository extends JpaRepository<ScheduleChange, Long> {
@@ -38,4 +42,8 @@ public interface ScheduleChangeRepository extends JpaRepository<ScheduleChange, 
     // 공종 필터 + 이력
     List<ScheduleChange> findAllByProject_IdxAndProcessAndStatusInOrderByProcessedAtDesc(
             Long projectId, String process, List<ScheduleChangeStatus> statuses);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update ScheduleChange sc set sc.tradeProcess = null where sc.tradeProcess.idx in :tradeProcessIds")
+    int clearTradeProcessByIds(@Param("tradeProcessIds") Collection<Long> tradeProcessIds);
 }

--- a/src/main/java/org/example/dndn/analysis/ScheduleChangeService.java
+++ b/src/main/java/org/example/dndn/analysis/ScheduleChangeService.java
@@ -3,6 +3,7 @@ package org.example.dndn.analysis;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.analysis.model.ScheduleChange;
 import org.example.dndn.analysis.model.ScheduleChangeDto;
 import org.example.dndn.analysis.model.ScheduleChangeStatus;
@@ -39,6 +40,7 @@ public class ScheduleChangeService {
     private final ProjectRepository projectRepository;
     private final TradeProcessRepository tradeProcessRepository;
     private final WorkPlanRepository workPlanRepository;
+    private final AuthAccessService authAccessService;
 
     // ── 요청 등록 (공정 책임자) ────────────────────────────────────────────
 
@@ -47,10 +49,16 @@ public class ScheduleChangeService {
         Project project = projectRepository.findById(dto.getProjectId())
                 .orElseThrow(() -> new RuntimeException("현장을 찾을 수 없습니다."));
 
+        authAccessService.assertProjectAccess(project.getIdx());
+
         TradeProcess tradeProcess = null;
         if (dto.getTradeProcessId() != null) {
             tradeProcess = tradeProcessRepository.findById(dto.getTradeProcessId())
                     .orElseThrow(() -> new RuntimeException("공정을 찾을 수 없습니다."));
+        }
+
+        if (tradeProcess != null) {
+            authAccessService.assertTradeProcessAccess(tradeProcess);
         }
 
         WorkPlan workPlan = null;
@@ -62,7 +70,12 @@ public class ScheduleChangeService {
             }
         }
 
+        if (workPlan != null) {
+            authAccessService.assertWorkPlanAccess(workPlan);
+        }
+
         String resolvedProcess = resolveProcess(dto, tradeProcess, workPlan);
+        authAccessService.assertTradeAccess(resolvedProcess);
         Optional<ScheduleChange> duplicate = findDuplicatePendingRequest(
                 project.getIdx(), dto, resolvedProcess, tradeProcess, workPlan);
         if (duplicate.isPresent()) {
@@ -106,22 +119,24 @@ public class ScheduleChangeService {
      */
     public List<ScheduleChangeDto.Res> listRequests(
             Long projectId, String process, String requester) {
+        authAccessService.assertProjectAccess(projectId);
+        String effectiveProcess = authAccessService.effectiveTrade(process);
 
         List<ScheduleChange> requests;
         List<ScheduleChangeStatus> activeStatuses = List.of(
                 ScheduleChangeStatus.PENDING,
                 ScheduleChangeStatus.APPROVED);
 
-        if (requester != null && !requester.isBlank()) {
+        if (requester != null && !requester.isBlank() && effectiveProcess != null && !effectiveProcess.isBlank()) {
             // 공정 책임자: 본인 요청만
             requests = changeRepository
                     .findAllByProject_IdxAndProcessAndRequesterAndStatusInOrderByCreatedAtDesc(
-                            projectId, process, requester, activeStatuses);
-        } else if (process != null && !process.isBlank()) {
+                            projectId, effectiveProcess, requester, activeStatuses);
+        } else if (effectiveProcess != null && !effectiveProcess.isBlank()) {
             // 총 책임자 + 공종 필터
             requests = changeRepository
                     .findAllByProject_IdxAndProcessAndStatusInOrderByCreatedAtDesc(
-                            projectId, process, activeStatuses);
+                            projectId, effectiveProcess, activeStatuses);
         } else {
             // 총 책임자 + 전체
             requests = changeRepository
@@ -129,41 +144,54 @@ public class ScheduleChangeService {
                             projectId, activeStatuses);
         }
 
-        return deduplicateRequests(requests).stream().map(ScheduleChangeDto.Res::from).toList();
+        return deduplicateRequests(requests).stream()
+                .filter(this::canAccessChange)
+                .filter(request -> requester == null || requester.isBlank() || requester.equals(request.getRequester()))
+                .map(ScheduleChangeDto.Res::from)
+                .toList();
     }
 
     /**
      * 변경 이력 — 처리 완료(APPROVED, APPLIED, REJECTED)된 항목
      */
     public List<ScheduleChangeDto.Res> listHistory(Long projectId, String process) {
+        authAccessService.assertProjectAccess(projectId);
+        String effectiveProcess = authAccessService.effectiveTrade(process);
         List<ScheduleChangeStatus> doneStatuses = List.of(
                 ScheduleChangeStatus.APPROVED,
                 ScheduleChangeStatus.APPLIED,
                 ScheduleChangeStatus.REJECTED);
 
-        List<ScheduleChange> history = (process != null && !process.isBlank())
+        List<ScheduleChange> history = (effectiveProcess != null && !effectiveProcess.isBlank())
                 ? changeRepository
                 .findAllByProject_IdxAndProcessAndStatusInOrderByProcessedAtDesc(
-                        projectId, process, doneStatuses)
+                        projectId, effectiveProcess, doneStatuses)
                 : changeRepository
                 .findAllByProject_IdxAndStatusInOrderByProcessedAtDesc(
                         projectId, doneStatuses);
 
-        return history.stream().map(ScheduleChangeDto.Res::from).toList();
+        return history.stream()
+                .filter(this::canAccessChange)
+                .map(ScheduleChangeDto.Res::from)
+                .toList();
     }
 
     // ── 승인 (총 책임자) ───────────────────────────────────────────────────
 
     @Transactional
     public void approve(Long requestId, ScheduleChangeDto.ApproveReq dto) {
-        findRequest(requestId).approve(dto.getApprover());
+        ScheduleChange request = findRequest(requestId);
+        assertChangeAccess(request);
+        request.approve(dto.getApprover());
     }
 
     // ── 반려 (총 책임자) ───────────────────────────────────────────────────
 
     @Transactional
     public void reject(Long requestId, ScheduleChangeDto.RejectReq dto) {
-        findRequest(requestId).reject(dto.getApprover(), dto.getRejectReason());
+        ScheduleChange request = findRequest(requestId);
+        assertChangeAccess(request);
+        request.reject(dto.getApprover(), dto.getRejectReason());
     }
 
     // ── 공정표 반영 (총 책임자) ────────────────────────────────────────────
@@ -179,6 +207,7 @@ public class ScheduleChangeService {
     @Transactional
     public void applyToSchedule(Long requestId) {
         ScheduleChange request = findRequest(requestId);
+        assertChangeAccess(request);
         if (request.getStatus() == ScheduleChangeStatus.APPLIED) {
             throw new IllegalStateException("이미 공정표에 반영된 요청입니다.");
         }
@@ -196,6 +225,7 @@ public class ScheduleChangeService {
             TradeProcess tradeProcess = request.getTradeProcess();
 
             workPlanRepository.findAllByTradeProcess_Idx(tradeProcess.getIdx()).stream()
+                    .filter(authAccessService::canAccessWorkPlan)
                     .forEach(wp -> syncWorkPlanExtension(wp, request));
         }
 
@@ -206,6 +236,27 @@ public class ScheduleChangeService {
     }
 
     // ── 내부 헬퍼 ─────────────────────────────────────────────────────────
+
+    private void assertChangeAccess(ScheduleChange request) {
+        if (!canAccessChange(request)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.FORBIDDEN,
+                    "No permission for this site or trade.");
+        }
+    }
+
+    private boolean canAccessChange(ScheduleChange request) {
+        if (request == null) return false;
+        Long projectId = request.getProject() != null ? request.getProject().getIdx() : null;
+        if (!authAccessService.canAccessProjectId(projectId)) return false;
+        if (request.getTradeProcess() != null && !authAccessService.canAccessTradeProcess(request.getTradeProcess())) {
+            return false;
+        }
+        if (request.getWorkPlan() != null && !authAccessService.canAccessWorkPlan(request.getWorkPlan())) {
+            return false;
+        }
+        return authAccessService.canAccessTradeName(request.getProcess());
+    }
 
     private Optional<ScheduleChange> findDuplicatePendingRequest(
             Long projectId,
@@ -323,6 +374,7 @@ public class ScheduleChangeService {
             WorkPlan workPlan = workPlanRepository.findById(workPlanId)
                     .orElseThrow(() -> new RuntimeException("변경 대상 작업 계획을 찾을 수 없습니다. id=" + workPlanId));
 
+            authAccessService.assertWorkPlanAccess(workPlan);
             applyDetailChangeToWorkPlan(workPlan, detail);
         }
     }

--- a/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
+++ b/src/main/java/org/example/dndn/auth/model/dto/AuthDto.java
@@ -33,6 +33,7 @@ public class AuthDto {
     public static class LoginRes {
         private String accessToken;
         private Long userIdx;
+        private Long projectId;
         private String name;
         private UserRole role;
         private String siteCode;

--- a/src/main/java/org/example/dndn/auth/security/AuthAccessService.java
+++ b/src/main/java/org/example/dndn/auth/security/AuthAccessService.java
@@ -1,0 +1,185 @@
+package org.example.dndn.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.model.entity.SystemUser;
+import org.example.dndn.auth.model.enums.UserRole;
+import org.example.dndn.auth.repository.SystemUserRepository;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.project.model.entity.TradeProcess;
+import org.example.dndn.project.repository.ProjectRepository;
+import org.example.dndn.workplan.model.entity.WorkPlan;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+@RequiredArgsConstructor
+public class AuthAccessService {
+
+    private static final Pattern SITE_CODE_PATTERN = Pattern.compile("^\\s*\\[([^\\]]+)]");
+
+    private final SystemUserRepository userRepository;
+    private final ProjectRepository projectRepository;
+
+    public Optional<SystemUser> currentUser() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof Long userIdx)) {
+            return Optional.empty();
+        }
+        SystemUser user = userRepository.findById(userIdx)
+                .filter(SystemUser::isActive)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.UNAUTHORIZED,
+                        "Invalid or inactive user."));
+        return Optional.of(user);
+    }
+
+    public boolean isTradeScoped(SystemUser user) {
+        if (user == null) return false;
+        return user.getRole() == UserRole.SECTION_LEADER
+                || user.getRole() == UserRole.SECTION_SUPERVISOR;
+    }
+
+    public boolean isSiteScoped(SystemUser user) {
+        if (user == null) return false;
+        return user.getRole() == UserRole.SITE_MANAGER
+                || user.getRole() == UserRole.SITE_DIRECTOR
+                || user.getRole() == UserRole.SECTION_LEADER
+                || user.getRole() == UserRole.SECTION_SUPERVISOR;
+    }
+
+    public String effectiveTrade(String requestedTrade) {
+        return currentUser()
+                .filter(this::isTradeScoped)
+                .map(SystemUser::getTrade)
+                .filter(trade -> trade != null && !trade.isBlank())
+                .orElse(requestedTrade);
+    }
+
+    public void assertProjectAccess(Long projectId) {
+        currentUser().ifPresent(user -> {
+            if (!canAccessProjectId(user, projectId)) {
+                throwForbidden();
+            }
+        });
+    }
+
+    public boolean canAccessProjectId(Long projectId) {
+        return currentUser()
+                .map(user -> canAccessProjectId(user, projectId))
+                .orElse(true);
+    }
+
+    public boolean canAccessTradeName(String tradeName) {
+        return currentUser()
+                .map(user -> canAccessTradeName(user, tradeName))
+                .orElse(true);
+    }
+
+    public void assertTradeAccess(String tradeName) {
+        currentUser().ifPresent(user -> {
+            if (!canAccessTradeName(user, tradeName)) {
+                throwForbidden();
+            }
+        });
+    }
+
+    public void assertWorkPlanAccess(WorkPlan plan) {
+        currentUser().ifPresent(user -> {
+            if (!canAccessWorkPlan(user, plan)) {
+                throwForbidden();
+            }
+        });
+    }
+
+    public boolean canAccessWorkPlan(WorkPlan plan) {
+        return currentUser()
+                .map(user -> canAccessWorkPlan(user, plan))
+                .orElse(true);
+    }
+
+    public boolean canAccessTradeProcess(TradeProcess tradeProcess) {
+        return currentUser()
+                .map(user -> canAccessTradeProcess(user, tradeProcess))
+                .orElse(true);
+    }
+
+    public void assertTradeProcessAccess(TradeProcess tradeProcess) {
+        currentUser().ifPresent(user -> {
+            if (!canAccessTradeProcess(user, tradeProcess)) {
+                throwForbidden();
+            }
+        });
+    }
+
+    public String workPlanTradeName(WorkPlan plan) {
+        if (plan == null) return "";
+        if (plan.getTradeProcess() != null && plan.getTradeProcess().getTradeName() != null) {
+            return plan.getTradeProcess().getTradeName();
+        }
+        return plan.getTrade() != null ? plan.getTrade().getLabel() : "";
+    }
+
+    public boolean tradeMatches(String recordTrade, String assignedTrade) {
+        String left = clean(recordTrade);
+        String right = clean(assignedTrade);
+        if (right.isBlank()) return true;
+        if (left.isBlank()) return false;
+        return left.equals(right) || left.contains(right) || right.contains(left);
+    }
+
+    private boolean canAccessWorkPlan(SystemUser user, WorkPlan plan) {
+        if (plan == null) return false;
+        TradeProcess tradeProcess = plan.getTradeProcess();
+        if (tradeProcess != null && !canAccessTradeProcess(user, tradeProcess)) {
+            return false;
+        }
+        return canAccessTradeName(user, workPlanTradeName(plan));
+    }
+
+    private boolean canAccessTradeProcess(SystemUser user, TradeProcess tradeProcess) {
+        if (tradeProcess == null) return true;
+        Long projectId = tradeProcess.getMasterSchedule() != null
+                && tradeProcess.getMasterSchedule().getProject() != null
+                ? tradeProcess.getMasterSchedule().getProject().getIdx()
+                : null;
+        return canAccessProjectId(user, projectId)
+                && canAccessTradeName(user, tradeProcess.getTradeName());
+    }
+
+    private boolean canAccessProjectId(SystemUser user, Long projectId) {
+        if (user == null || projectId == null) return true;
+        if (!isSiteScoped(user)) return true;
+
+        String assignedSiteCode = clean(user.getSiteCode());
+        if (assignedSiteCode.isBlank()) return true;
+
+        return projectRepository.findById(projectId)
+                .map(project -> assignedSiteCode.equalsIgnoreCase(projectSiteCode(project)))
+                .orElse(false);
+    }
+
+    private boolean canAccessTradeName(SystemUser user, String tradeName) {
+        if (!isTradeScoped(user)) return true;
+        return tradeMatches(tradeName, user.getTrade());
+    }
+
+    private String projectSiteCode(Project project) {
+        if (project == null || project.getName() == null) return "";
+        Matcher matcher = SITE_CODE_PATTERN.matcher(project.getName());
+        return matcher.find() ? clean(matcher.group(1)) : "";
+    }
+
+    private String clean(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    private void throwForbidden() {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission for this site or trade.");
+    }
+}

--- a/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
+++ b/src/main/java/org/example/dndn/auth/security/SecurityConfig.java
@@ -37,6 +37,16 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .requestMatchers("/account-requests").authenticated()
+                        .requestMatchers(
+                                "/project/**",
+                                "/master-schedule/**",
+                                "/trade-process/**",
+                                "/work-plan/**",
+                                "/work-order/**",
+                                "/report/**",
+                                "/analysis/**",
+                                "/schedule-change-request/**"
+                        ).authenticated()
                         .anyRequest().permitAll()   // 기존 엔드포인트는 현행 유지 (추후 역할별 제한 추가)
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/org/example/dndn/auth/service/AuthService.java
+++ b/src/main/java/org/example/dndn/auth/service/AuthService.java
@@ -6,6 +6,8 @@ import org.example.dndn.auth.model.entity.SystemUser;
 import org.example.dndn.auth.repository.SystemUserRepository;
 import org.example.dndn.auth.security.JwtProvider;
 import org.example.dndn.common.exception.BaseException;
+import org.example.dndn.project.model.entity.Project;
+import org.example.dndn.project.repository.ProjectRepository;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ public class AuthService {
     private final SystemUserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
+    private final ProjectRepository projectRepository;
 
     @Transactional
     public void changePassword(AuthDto.ChangePasswordReq req) {
@@ -59,10 +62,28 @@ public class AuthService {
         return AuthDto.LoginRes.builder()
                 .accessToken(token)
                 .userIdx(user.getIdx())
+                .projectId(resolveProjectId(user.getSiteCode()))
                 .name(user.getName())
                 .role(user.getRole())
                 .siteCode(user.getSiteCode())
                 .trade(user.getTrade())
                 .build();
+    }
+
+    private Long resolveProjectId(String siteCode) {
+        if (siteCode == null || siteCode.isBlank()) {
+            return null;
+        }
+        String prefix = "[" + siteCode.trim() + "]";
+        return projectRepository.findAll().stream()
+                .filter(project -> startsWithSiteCode(project, prefix))
+                .map(Project::getIdx)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean startsWithSiteCode(Project project, String prefix) {
+        String name = project.getName();
+        return name != null && name.trim().startsWith(prefix);
     }
 }

--- a/src/main/java/org/example/dndn/project/controller/TradeProcessController.java
+++ b/src/main/java/org/example/dndn/project/controller/TradeProcessController.java
@@ -32,9 +32,10 @@ public class TradeProcessController {
     @GetMapping
     public ResponseEntity<?> list(
             @RequestParam("projectId") Long projectId,
-            @RequestParam(value = "tradeName", required = false) String tradeName) {
+            @RequestParam(value = "tradeName", required = false) String tradeName,
+            @RequestParam(value = "includeAllTrades", defaultValue = "false") boolean includeAllTrades) {
         return ResponseEntity.ok(BaseResponse.success(
-                tradeProcessService.listByProject(projectId, tradeName)));
+                tradeProcessService.listByProject(projectId, tradeName, includeAllTrades)));
     }
 
     /**
@@ -51,9 +52,11 @@ public class TradeProcessController {
     // 공정표별 공정 목록
     // GET /trade-process/by-schedule/1
     @GetMapping("/by-schedule/{scheduleId}")
-    public ResponseEntity<?> listBySchedule(@PathVariable("scheduleId") Long scheduleId) {
+    public ResponseEntity<?> listBySchedule(
+            @PathVariable("scheduleId") Long scheduleId,
+            @RequestParam(value = "includeAllTrades", defaultValue = "false") boolean includeAllTrades) {
         return ResponseEntity.ok(BaseResponse.success(
-                tradeProcessService.listBySchedule(scheduleId)));
+                tradeProcessService.listBySchedule(scheduleId, includeAllTrades)));
     }
 
     @PutMapping("/{tpId}")

--- a/src/main/java/org/example/dndn/project/repository/MasterScheduleRepository.java
+++ b/src/main/java/org/example/dndn/project/repository/MasterScheduleRepository.java
@@ -3,7 +3,11 @@ package org.example.dndn.project.repository;
 import org.example.dndn.project.model.enums.DocType;
 import org.example.dndn.project.model.entity.MasterSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface MasterScheduleRepository extends JpaRepository<MasterSchedule, Long> {
@@ -11,4 +15,8 @@ public interface MasterScheduleRepository extends JpaRepository<MasterSchedule, 
     List<MasterSchedule> findAllByProject_Idx(Long projectId);
 
     List<MasterSchedule> findAllByProject_IdxAndDocType(Long projectId, DocType docType);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from MasterSchedule ms where ms.idx in :scheduleIds")
+    int deleteByIds(@Param("scheduleIds") Collection<Long> scheduleIds);
 }

--- a/src/main/java/org/example/dndn/project/repository/MilestoneRepository.java
+++ b/src/main/java/org/example/dndn/project/repository/MilestoneRepository.java
@@ -1,0 +1,16 @@
+package org.example.dndn.project.repository;
+
+import org.example.dndn.project.model.entity.Milestone;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+
+public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from Milestone m where m.tradeProcess.idx in :tradeProcessIds")
+    int deleteByTradeProcessIds(@Param("tradeProcessIds") Collection<Long> tradeProcessIds);
+}

--- a/src/main/java/org/example/dndn/project/repository/ScheduleAiAnalysisRepository.java
+++ b/src/main/java/org/example/dndn/project/repository/ScheduleAiAnalysisRepository.java
@@ -2,10 +2,18 @@ package org.example.dndn.project.repository;
 
 import org.example.dndn.project.model.entity.ScheduleAiAnalysis;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface ScheduleAiAnalysisRepository extends JpaRepository<ScheduleAiAnalysis, Long> {
 
     List<ScheduleAiAnalysis> findByMasterSchedule_Idx(Long masterScheduleId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from ScheduleAiAnalysis saa where saa.masterSchedule.idx in :masterScheduleIds")
+    int deleteByMasterScheduleIds(@Param("masterScheduleIds") Collection<Long> masterScheduleIds);
 }

--- a/src/main/java/org/example/dndn/project/repository/TradeProcessRepository.java
+++ b/src/main/java/org/example/dndn/project/repository/TradeProcessRepository.java
@@ -2,18 +2,26 @@ package org.example.dndn.project.repository;
 
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface TradeProcessRepository extends JpaRepository<TradeProcess, Long> {
 
     List<TradeProcess> findAllByMasterSchedule_Idx(Long masterScheduleId);
 
+    List<TradeProcess> findAllByMasterSchedule_IdxIn(Collection<Long> masterScheduleIds);
+
     List<TradeProcess> findAllByMasterSchedule_Project_Idx(Long projectId);
 
     List<TradeProcess> findAllByMasterSchedule_Project_IdxAndTradeName(Long projectId, String tradeName);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from TradeProcess tp where tp.masterSchedule.idx in :masterScheduleIds")
+    int deleteByMasterScheduleIds(@Param("masterScheduleIds") Collection<Long> masterScheduleIds);
 
     /**
      * 현장(project) 에 연결된 master_schedule 의 trade_process 중

--- a/src/main/java/org/example/dndn/project/service/MasterScheduleService.java
+++ b/src/main/java/org/example/dndn/project/service/MasterScheduleService.java
@@ -2,6 +2,7 @@ package org.example.dndn.project.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.dndn.ai.extractor.ScheduleDocumentExtractor;
+import org.example.dndn.analysis.ScheduleChangeRepository;
 import org.example.dndn.project.model.dto.MasterScheduleDto;
 import org.example.dndn.project.model.dto.TradeProcessDto;
 import org.example.dndn.project.model.entity.MasterSchedule;
@@ -9,8 +10,11 @@ import org.example.dndn.project.model.entity.Project;
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.example.dndn.project.model.enums.DocType;
 import org.example.dndn.project.repository.MasterScheduleRepository;
+import org.example.dndn.project.repository.MilestoneRepository;
 import org.example.dndn.project.repository.ProjectRepository;
+import org.example.dndn.project.repository.ScheduleAiAnalysisRepository;
 import org.example.dndn.project.repository.TradeProcessRepository;
+import org.example.dndn.workplan.WorkPlanRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +32,10 @@ public class MasterScheduleService {
     private final TradeProcessRepository tradeProcessRepository;
     private final MasterScheduleRepository masterScheduleRepository;
     private final ProjectRepository projectRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final ScheduleAiAnalysisRepository scheduleAiAnalysisRepository;
+    private final WorkPlanRepository workPlanRepository;
+    private final ScheduleChangeRepository scheduleChangeRepository;
 
     @Transactional
     public Long create(MasterScheduleDto.Req dto) {
@@ -105,6 +113,8 @@ public class MasterScheduleService {
 
             file.transferTo(filePath.toFile());
 
+            replacePreviousExtraction(projectId, docType);
+
             MasterSchedule schedule = MasterSchedule.builder()
                     .project(project)
                     .docType(docType)
@@ -140,5 +150,35 @@ public class MasterScheduleService {
         } catch (Exception e) {
             throw new RuntimeException("공정표 업로드 및 AI 분석 중 오류가 발생했습니다.", e);
         }
+    }
+
+    private void replacePreviousExtraction(Long projectId, DocType docType) {
+        List<MasterSchedule> previousSchedules = docType == DocType.MASTER
+                ? masterScheduleRepository.findAllByProject_Idx(projectId)
+                : masterScheduleRepository.findAllByProject_IdxAndDocType(projectId, docType);
+
+        if (previousSchedules.isEmpty()) {
+            return;
+        }
+
+        List<Long> scheduleIds = previousSchedules.stream()
+                .map(MasterSchedule::getIdx)
+                .toList();
+
+        List<TradeProcess> previousTradeProcesses =
+                tradeProcessRepository.findAllByMasterSchedule_IdxIn(scheduleIds);
+        List<Long> tradeProcessIds = previousTradeProcesses.stream()
+                .map(TradeProcess::getIdx)
+                .toList();
+
+        if (!tradeProcessIds.isEmpty()) {
+            workPlanRepository.clearTradeProcessByIds(tradeProcessIds);
+            scheduleChangeRepository.clearTradeProcessByIds(tradeProcessIds);
+            milestoneRepository.deleteByTradeProcessIds(tradeProcessIds);
+            tradeProcessRepository.deleteByMasterScheduleIds(scheduleIds);
+        }
+
+        scheduleAiAnalysisRepository.deleteByMasterScheduleIds(scheduleIds);
+        masterScheduleRepository.deleteByIds(scheduleIds);
     }
 }

--- a/src/main/java/org/example/dndn/project/service/ProjectService.java
+++ b/src/main/java/org/example/dndn/project/service/ProjectService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.project.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.project.model.entity.Project;
 import org.example.dndn.project.model.dto.ProjectDto;
 import org.example.dndn.project.repository.ProjectRepository;
@@ -15,6 +16,7 @@ import java.util.List;
 public class ProjectService {
 
     private final ProjectRepository projectRepository;
+    private final AuthAccessService authAccessService;
 
     @Transactional
     public Long create(ProjectDto.Req dto) {
@@ -22,17 +24,20 @@ public class ProjectService {
     }
 
     public ProjectDto.Res read(Long projectId) {
+        authAccessService.assertProjectAccess(projectId);
         return ProjectDto.Res.from(findProject(projectId));
     }
 
     public List<ProjectDto.Res> list() {
         return projectRepository.findAll().stream()
+                .filter(project -> authAccessService.canAccessProjectId(project.getIdx()))
                 .map(ProjectDto.Res::from)
                 .toList();
     }
 
     @Transactional
     public void update(Long projectId, ProjectDto.Req dto) {
+        authAccessService.assertProjectAccess(projectId);
         findProject(projectId).update(
                 dto.getName(),
                 dto.getLocation(),
@@ -43,6 +48,7 @@ public class ProjectService {
 
     @Transactional
     public void delete(Long projectId) {
+        authAccessService.assertProjectAccess(projectId);
         projectRepository.delete(findProject(projectId));
     }
 

--- a/src/main/java/org/example/dndn/project/service/TradeProcessService.java
+++ b/src/main/java/org/example/dndn/project/service/TradeProcessService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.project.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.project.model.entity.MasterSchedule;
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.example.dndn.project.model.dto.TradeProcessDto;
@@ -21,11 +22,15 @@ public class TradeProcessService {
     private final TradeProcessRepository tradeProcessRepository;
     private final MasterScheduleRepository masterScheduleRepository;
     private final ScheduleDocumentExtractor scheduleDocumentExtractor;
+    private final AuthAccessService authAccessService;
 
     @Transactional
     public Long create(TradeProcessDto.Req dto) {
         MasterSchedule schedule = masterScheduleRepository.findById(dto.getMasterScheduleId())
                 .orElseThrow(() -> new RuntimeException("공정표를 찾을 수 없습니다."));
+
+        authAccessService.assertProjectAccess(schedule.getProject() != null ? schedule.getProject().getIdx() : null);
+        authAccessService.assertTradeAccess(dto.getTradeName());
 
         TradeProcess tp = TradeProcess.builder()
                 .masterSchedule(schedule)
@@ -50,7 +55,10 @@ public class TradeProcessService {
         MasterSchedule schedule = masterScheduleRepository.findById(masterScheduleId)
                 .orElseThrow(() -> new RuntimeException("공정표를 찾을 수 없습니다."));
 
+        authAccessService.assertProjectAccess(schedule.getProject() != null ? schedule.getProject().getIdx() : null);
+
         List<TradeProcess> entities = dtoList.stream()
+                .peek(dto -> authAccessService.assertTradeAccess(dto.getTradeName()))
                 .map(dto -> TradeProcess.builder()
                         .masterSchedule(schedule)
                         .tradeName(dto.getTradeName())
@@ -78,21 +86,40 @@ public class TradeProcessService {
     }
 
     public TradeProcessDto.Res read(Long tpId) {
-        return TradeProcessDto.Res.from(findTradeProcess(tpId));
+        TradeProcess tradeProcess = findTradeProcess(tpId);
+        authAccessService.assertTradeProcessAccess(tradeProcess);
+        return TradeProcessDto.Res.from(tradeProcess);
     }
 
     // 현장별 공정 목록 (공종 필터 선택) — WorkPlan 등록 시 선택용으로도 사용
     public List<TradeProcessDto.Res> listByProject(Long projectId, String tradeName) {
-        List<TradeProcess> list = (tradeName == null || tradeName.isBlank())
-                ? tradeProcessRepository.findAllByMasterSchedule_Project_Idx(projectId)
-                : tradeProcessRepository.findAllByMasterSchedule_Project_IdxAndTradeName(projectId, tradeName);
+        return listByProject(projectId, tradeName, false);
+    }
 
-        return list.stream().map(TradeProcessDto.Res::from).toList();
+    public List<TradeProcessDto.Res> listByProject(Long projectId, String tradeName, boolean includeAllTrades) {
+        authAccessService.assertProjectAccess(projectId);
+        String effectiveTrade = includeAllTrades ? tradeName : authAccessService.effectiveTrade(tradeName);
+        List<TradeProcess> list = tradeProcessRepository.findAllByMasterSchedule_Project_Idx(projectId);
+
+        return list.stream()
+                .filter(tp -> authAccessService.tradeMatches(tp.getTradeName(), effectiveTrade))
+                .filter(tp -> includeAllTrades || authAccessService.canAccessTradeProcess(tp))
+                .map(TradeProcessDto.Res::from)
+                .toList();
     }
 
     // 공정표별 공정 목록
     public List<TradeProcessDto.Res> listBySchedule(Long scheduleId) {
+        return listBySchedule(scheduleId, false);
+    }
+
+    public List<TradeProcessDto.Res> listBySchedule(Long scheduleId, boolean includeAllTrades) {
+        MasterSchedule schedule = masterScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new RuntimeException("怨듭젙?쒕? 李얠쓣 ???놁뒿?덈떎."));
+        authAccessService.assertProjectAccess(schedule.getProject() != null ? schedule.getProject().getIdx() : null);
+
         return tradeProcessRepository.findAllByMasterSchedule_Idx(scheduleId).stream()
+                .filter(tp -> includeAllTrades || authAccessService.canAccessTradeProcess(tp))
                 .map(TradeProcessDto.Res::from)
                 .toList();
     }
@@ -103,12 +130,18 @@ public class TradeProcessService {
      * isMilestone = true 이고 '준공', '착공' 을 제외한 공종명 목록을 반환.
      */
     public List<String> listMilestoneTradeNamesByProject(Long projectId) {
-        return tradeProcessRepository.findMilestoneTradeNamesByProjectId(projectId);
+        authAccessService.assertProjectAccess(projectId);
+        return tradeProcessRepository.findMilestoneTradeNamesByProjectId(projectId).stream()
+                .filter(authAccessService::canAccessTradeName)
+                .toList();
     }
 
     @Transactional
     public void update(Long tpId, TradeProcessDto.Req dto) {
-        findTradeProcess(tpId).update(
+        TradeProcess tradeProcess = findTradeProcess(tpId);
+        authAccessService.assertTradeProcessAccess(tradeProcess);
+        authAccessService.assertTradeAccess(dto.getTradeName());
+        tradeProcess.update(
                 dto.getTradeName(),
                 dto.getProcessName(),
                 dto.getPartnerCompany(),
@@ -121,7 +154,9 @@ public class TradeProcessService {
 
     @Transactional
     public void delete(Long tpId) {
-        tradeProcessRepository.delete(findTradeProcess(tpId));
+        TradeProcess tradeProcess = findTradeProcess(tpId);
+        authAccessService.assertTradeProcessAccess(tradeProcess);
+        tradeProcessRepository.delete(tradeProcess);
     }
 
     private TradeProcess findTradeProcess(Long tpId) {

--- a/src/main/java/org/example/dndn/report/DailyReportService.java
+++ b/src/main/java/org/example/dndn/report/DailyReportService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.report;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.report.model.DailyReport;
 import org.example.dndn.report.model.ReportDto;
 import org.example.dndn.workplan.WorkPlanRepository;
@@ -26,6 +27,7 @@ public class DailyReportService {
 
     private final DailyReportRepository dailyReportRepository;
     private final WorkPlanRepository workPlanRepository;
+    private final AuthAccessService authAccessService;
 
     // feat : 공사일보 제출 및 명일 작업계획 자동 연동
     public Long submitReport(ReportDto.Req dto) {
@@ -33,6 +35,7 @@ public class DailyReportService {
         // feat : 공사일보 DB 조회 및 저장
         WorkPlan workPlan = workPlanRepository.findById(dto.getWorkPlanId())
                 .orElseThrow(() -> new RuntimeException("WorkPlan not found"));
+        authAccessService.assertWorkPlanAccess(workPlan);
 
         DailyReport dailyReport = dailyReportRepository.findByWorkPlan_IdxAndReportDate(workPlan.getIdx(), dto.getReportDate())
                 .orElse(DailyReport.builder()
@@ -44,6 +47,10 @@ public class DailyReportService {
         if (dto.getMonthlyWorkPlanId() != null) {
             monthlyPlan = workPlanRepository.findById(dto.getMonthlyWorkPlanId())
                     .orElseThrow(() -> new RuntimeException("월간 세부계획을 찾을 수 없습니다. id=" + dto.getMonthlyWorkPlanId()));
+        }
+
+        if (monthlyPlan != null) {
+            authAccessService.assertWorkPlanAccess(monthlyPlan);
         }
 
         Double monthlyProgressPct = clampPercent(dto.getMonthlyProgressPct() != null
@@ -101,6 +108,8 @@ public class DailyReportService {
                     .orElseThrow(() -> new RuntimeException("대상 주간계획을 찾을 수 없습니다."));
 
             // feat : 기존 주간 계획을 유지하되, '비고(note)'와 인원/장비만 명일 작업 예정으로 덮어씀
+            authAccessService.assertWorkPlanAccess(tomorrowPlan);
+
             tomorrowPlan.updateInfo(
                     tomorrowPlan.getName(), tomorrowPlan.getTrade(), tomorrowPlan.getLocation(),
                     tomorrowPlan.getStartDate(), tomorrowPlan.getEndDate(), tomorrowPlan.getStatus(),
@@ -165,11 +174,13 @@ public class DailyReportService {
     // feat : 특정 일자 공사일보 목록 조회 및 DTO 변환
     @Transactional(readOnly = true)
     public List<ReportDto.Res> getReportsByDate(LocalDate date) {
-        return dailyReportRepository.findByReportDate(date).stream().map(r ->
+        return dailyReportRepository.findByReportDate(date).stream()
+                .filter(r -> authAccessService.canAccessWorkPlan(r.getWorkPlan()))
+                .map(r ->
                 ReportDto.Res.builder()
                         .idx(r.getIdx())
                         .workPlanId(r.getWorkPlan().getIdx())
-                        .process(r.getWorkPlan().getTrade() != null ? r.getWorkPlan().getTrade().getLabel() : "")
+                        .process(authAccessService.workPlanTradeName(r.getWorkPlan()))
                         .actualProgress(r.getActualProgress())
                         .todayProgress(r.getTodayProgress())
                         .monthlyWorkPlanId(r.getMonthlyWorkPlan() != null ? r.getMonthlyWorkPlan().getIdx() : null)

--- a/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderRepository.java
@@ -30,7 +30,8 @@ public interface WorkOrderRepository extends JpaRepository<WorkOrder, Long> {
                     we.gate_idx,
                     we.equipment_name,
                     we.equipment_count,
-                    wo.status_code
+                    wo.status_code,
+                    wo.site_idx
             FROM work_order wo
             JOIN work_order_equipment we ON we.work_order_idx = wo.idx
             LEFT JOIN work_plan wp ON wp.idx = wo.work_plan_id

--- a/src/main/java/org/example/dndn/workorder/WorkOrderService.java
+++ b/src/main/java/org/example/dndn/workorder/WorkOrderService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.workorder;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.workorder.model.WorkOrder;
 import org.example.dndn.workorder.model.WorkOrderDto;
 import org.example.dndn.workorder.model.WorkOrderEquipment;
@@ -28,11 +29,14 @@ public class WorkOrderService {
     private final WorkOrderRepository workOrderRepository;
     private final WorkOrderEquipmentRepository workOrderEquipmentRepository;
     private final WorkPlanRepository workPlanRepository;
+    private final AuthAccessService authAccessService;
 
     // [WORKORDER_001] 1단계 : 작업 지시서 기본 작성 기능
     // feat : 작업 지시서 신규 생성
     @Transactional
     public void createWorkOrder(WorkOrderDto.Req req) {
+        assertRequestAccess(req);
+
         WorkOrder workOrder = WorkOrder.builder()
                 .siteIdx(req.getSiteIdx())
                 .partnerCompanyIdx(req.getPartnerCompanyIdx())
@@ -75,7 +79,9 @@ public class WorkOrderService {
     // feat : 작업 지시서 목록 전체 조회
     @Transactional(readOnly = true)
     public List<WorkOrderDto.Res> getWorkOrderList() {
-        return workOrderRepository.findAll().stream().map(order -> {
+        return workOrderRepository.findAll().stream()
+                .filter(this::canAccessWorkOrder)
+                .map(order -> {
             List<WorkOrderEquipmentDto> eqDtos = order.getEquipments().stream()
                     .map(eq -> WorkOrderEquipmentDto.builder()
                             .idx(eq.getIdx())
@@ -109,6 +115,8 @@ public class WorkOrderService {
     @Transactional(readOnly = true)
     public List<WorkOrderDto.GateEquipmentRes> getGateEquipments(LocalDate targetDate) {
         return workOrderRepository.findGateEquipmentsByTargetDate(targetDate).stream()
+                .filter(row -> authAccessService.canAccessProjectId(toLong(row[12]))
+                        && authAccessService.canAccessTradeName(toStringValue(row[3])))
                 .map(row -> {
                     LocalDate workDate = toLocalDate(row[5]);
                     String title = toStringValue(row[2]);
@@ -142,6 +150,9 @@ public class WorkOrderService {
                 .orElseThrow(() -> new RuntimeException("작업 지시서를 찾을 수 없습니다."));
 
         // feat : 기본 정보 업데이트
+        assertWorkOrderAccess(workOrder);
+        assertRequestAccess(req);
+
         workOrder.setSiteIdx(req.getSiteIdx());
         workOrder.setPartnerCompanyIdx(req.getPartnerCompanyIdx());
         workOrder.setWorkPlanId(req.getWorkPlanId());
@@ -180,6 +191,7 @@ public class WorkOrderService {
     // feat : 초안 생성 시 장비만 별도로 조회하여 반환
     @Transactional(readOnly = true)
     public List<WorkOrderEquipmentDto> getDraftEquipments(Long planIdx) {
+        workPlanRepository.findById(planIdx).ifPresent(authAccessService::assertWorkPlanAccess);
         List<Object[]> results = workOrderRepository.findEquipmentsByPlanIdx(planIdx);
 
         return results.stream().map(row -> {
@@ -201,6 +213,8 @@ public class WorkOrderService {
         WorkOrder workOrder = workOrderRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("작업 지시서를 찾을 수 없습니다."));
 
+        assertWorkOrderAccess(workOrder);
+
         if (workOrder.getWorkPlanId() == null) {
             throw new RuntimeException("연결된 주간 작업 계획이 없습니다.");
         }
@@ -210,6 +224,8 @@ public class WorkOrderService {
 
         // 1. 기본 정보 및 '비고'에 지시서 내용 반영
         // feat : 승인된 작업지시서 내용을 주간 작업 계획의 비고에 반영
+        authAccessService.assertWorkPlanAccess(weeklyPlan);
+
         weeklyPlan.updateInfo(
                 weeklyPlan.getName(),
                 weeklyPlan.getTrade(),
@@ -254,6 +270,33 @@ public class WorkOrderService {
         workOrder.setStatusCode("APPROVED");
         // JPA 감지로 인해 weeklyPlan 변경사항이 자동 저장됩니다.
     }
+    private void assertRequestAccess(WorkOrderDto.Req req) {
+        if (req == null) {
+            return;
+        }
+        authAccessService.assertProjectAccess(req.getSiteIdx());
+        authAccessService.assertTradeAccess(req.getTradeType());
+        if (req.getWorkPlanId() != null) {
+            WorkPlan workPlan = workPlanRepository.findById(req.getWorkPlanId())
+                    .orElseThrow(() -> new RuntimeException("WorkPlan not found. id=" + req.getWorkPlanId()));
+            authAccessService.assertWorkPlanAccess(workPlan);
+        }
+    }
+
+    private void assertWorkOrderAccess(WorkOrder workOrder) {
+        if (!canAccessWorkOrder(workOrder)) {
+            throw new org.springframework.web.server.ResponseStatusException(
+                    org.springframework.http.HttpStatus.FORBIDDEN,
+                    "No permission for this site or trade.");
+        }
+    }
+
+    private boolean canAccessWorkOrder(WorkOrder workOrder) {
+        return workOrder != null
+                && authAccessService.canAccessProjectId(workOrder.getSiteIdx())
+                && authAccessService.canAccessTradeName(workOrder.getTradeType());
+    }
+
     private Long toLong(Object value) {
         if (value == null) {
             return null;

--- a/src/main/java/org/example/dndn/workplan/WorkPlanController.java
+++ b/src/main/java/org/example/dndn/workplan/WorkPlanController.java
@@ -33,9 +33,11 @@ public class WorkPlanController {
         return ResponseEntity.ok(BaseResponse.success(dto));
     }
     @GetMapping("/project/{projectId}")
-    public ResponseEntity<?> listByProject(@PathVariable Long projectId) {
+    public ResponseEntity<?> listByProject(
+            @PathVariable Long projectId,
+            @RequestParam(value = "includeAllTrades", defaultValue = "false") boolean includeAllTrades) {
         return ResponseEntity.ok(BaseResponse.success(
-                workPlanService.listByProject(projectId)
+                workPlanService.listByProject(projectId, includeAllTrades)
         ));
     }
 
@@ -43,9 +45,10 @@ public class WorkPlanController {
     @GetMapping
     public ResponseEntity<?> list(
             @RequestParam(value = "planType", defaultValue = "월간") String planType,
+            @RequestParam(value = "projectId", required = false) Long projectId,
             @RequestParam(value = "trade", required = false) String trade,
             @RequestParam(value = "status", required = false) String status) {
-        List<WorkPlanDto.workPlanRes> dtos = workPlanService.list(planType, trade, status);
+        List<WorkPlanDto.workPlanRes> dtos = workPlanService.list(projectId, planType, trade, status);
         return ResponseEntity.ok(BaseResponse.success(dtos));
     }
 

--- a/src/main/java/org/example/dndn/workplan/WorkPlanRepository.java
+++ b/src/main/java/org/example/dndn/workplan/WorkPlanRepository.java
@@ -5,7 +5,11 @@ import org.example.dndn.workplan.model.enums.PlanType;
 import org.example.dndn.workplan.model.entity.WorkPlan;
 import org.example.dndn.workplan.model.enums.WorkTrade;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface WorkPlanRepository extends JpaRepository<WorkPlan, Long> {
@@ -26,4 +30,8 @@ public interface WorkPlanRepository extends JpaRepository<WorkPlan, Long> {
     List<WorkPlan> findAllByTradeProcess_Idx(Long tradeProcessId);
 
     List<WorkPlan> findAllByParentWorkPlan_Idx(Long parentWorkPlanId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update WorkPlan wp set wp.tradeProcess = null where wp.tradeProcess.idx in :tradeProcessIds")
+    int clearTradeProcessByIds(@Param("tradeProcessIds") Collection<Long> tradeProcessIds);
 }

--- a/src/main/java/org/example/dndn/workplan/WorkPlanService.java
+++ b/src/main/java/org/example/dndn/workplan/WorkPlanService.java
@@ -1,6 +1,7 @@
 package org.example.dndn.workplan;
 
 import lombok.RequiredArgsConstructor;
+import org.example.dndn.auth.security.AuthAccessService;
 import org.example.dndn.project.repository.TradeProcessRepository;
 import org.example.dndn.project.model.entity.TradeProcess;
 import org.example.dndn.report.DailyReportRepository;
@@ -27,6 +28,7 @@ public class WorkPlanService {
 
     private final WorkPlanRepository workPlanRepository;
     private final DailyReportRepository dailyReportRepository;
+    private final AuthAccessService authAccessService;
     // ── 1단계 추가 ─────────────────────────────────────────────────────────
     private final TradeProcessRepository tradeProcessRepository;
     // ────────────────────────────────────────────────────────────────────────
@@ -38,31 +40,44 @@ public class WorkPlanService {
 
         linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
         linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
+        authAccessService.assertWorkPlanAccess(plan);
 
         return workPlanRepository.save(plan).getIdx();
     }
 
     public List<WorkPlanDto.workPlanRes> listByProject(Long projectId) {
+        return listByProject(projectId, false);
+    }
+
+    public List<WorkPlanDto.workPlanRes> listByProject(Long projectId, boolean includeAllTrades) {
+        authAccessService.assertProjectAccess(projectId);
         return workPlanRepository.findAllByTradeProcess_MasterSchedule_Project_Idx(projectId)
                 .stream()
+                .filter(plan -> includeAllTrades || authAccessService.canAccessWorkPlan(plan))
                 .map(this::toWorkPlanResWithReportProgress)
                 .toList();
     }
 
     // 작업 계획 단일 조회
     public WorkPlanDto.Res read(Long planId) {
-        return WorkPlanDto.Res.from(findPlan(planId));
+        WorkPlan plan = findPlan(planId);
+        authAccessService.assertWorkPlanAccess(plan);
+        return WorkPlanDto.Res.from(plan);
     }
 
     // 작업 계획 목록 조회 (계획 종류 + 공종/상태 필터)
-    public List<WorkPlanDto.workPlanRes> list(String planType, String trade, String status) {
+    public List<WorkPlanDto.workPlanRes> list(Long projectId, String planType, String trade, String status) {
         PlanType type = PlanType.fromLabel(planType);
         WorkTrade tradeEnum = WorkTrade.fromLabel(trade);
         PlanStatus statusEnum = (status == null || status.isBlank())
                 ? null : PlanStatus.fromLabel(status);
+        String effectiveTrade = authAccessService.effectiveTrade(trade);
 
         List<WorkPlan> plans;
-        if (tradeEnum != null && statusEnum != null) {
+        if (projectId != null) {
+            authAccessService.assertProjectAccess(projectId);
+            plans = workPlanRepository.findAllByTradeProcess_MasterSchedule_Project_Idx(projectId);
+        } else if (tradeEnum != null && statusEnum != null) {
             plans = workPlanRepository.findAllByPlanTypeAndTradeAndStatus(type, tradeEnum, statusEnum);
         } else if (tradeEnum != null) {
             plans = workPlanRepository.findAllByPlanTypeAndTrade(type, tradeEnum);
@@ -72,13 +87,22 @@ public class WorkPlanService {
             plans = workPlanRepository.findAllByPlanType(type);
         }
 
-        return plans.stream().map(this::toWorkPlanResWithReportProgress).toList();
+        return plans.stream()
+                .filter(plan -> plan.getPlanType() == type)
+                .filter(plan -> statusEnum == null || plan.getStatus() == statusEnum)
+                .filter(plan -> authAccessService.tradeMatches(
+                        authAccessService.workPlanTradeName(plan),
+                        effectiveTrade))
+                .filter(authAccessService::canAccessWorkPlan)
+                .map(this::toWorkPlanResWithReportProgress)
+                .toList();
     }
 
     // 작업 계획 정보 수정
     @Transactional
     public void update(Long planId, WorkPlanDto.Req dto) {
         WorkPlan plan = findPlan(planId);
+        authAccessService.assertWorkPlanAccess(plan);
 
         plan.updateInfo(
                 dto.getName(),
@@ -107,12 +131,14 @@ public class WorkPlanService {
 
         linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
         linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
+        authAccessService.assertWorkPlanAccess(plan);
     }
 
     // 일정 연장 등록/수정
     @Transactional
     public void extend(Long planId, WorkPlanDto.ExtReq dto) {
         WorkPlan plan = findPlan(planId);
+        authAccessService.assertWorkPlanAccess(plan);
         WorkPlanExtension extension = plan.getExtension();
 
         if (extension == null) {
@@ -167,6 +193,7 @@ public class WorkPlanService {
 
             linkTradeProcessIfPresent(plan, dto.getTradeProcessId());
             linkParentWorkPlanIfPresent(plan, dto.getParentWorkPlanId());
+            authAccessService.assertWorkPlanAccess(plan);
 
             savedIds.add(workPlanRepository.save(plan).getIdx());
         }
@@ -177,13 +204,17 @@ public class WorkPlanService {
     // 작업 착수 처리
     @Transactional
     public void start(Long planId) {
-        findPlan(planId).markStarted(LocalDate.now());
+        WorkPlan plan = findPlan(planId);
+        authAccessService.assertWorkPlanAccess(plan);
+        plan.markStarted(LocalDate.now());
     }
 
     // 작업 계획 삭제
     @Transactional
     public void delete(Long planId) {
-        workPlanRepository.delete(findPlan(planId));
+        WorkPlan plan = findPlan(planId);
+        authAccessService.assertWorkPlanAccess(plan);
+        workPlanRepository.delete(plan);
     }
 
 
@@ -232,6 +263,7 @@ public class WorkPlanService {
         TradeProcess tradeProcess = tradeProcessRepository.findById(tradeProcessId)
                 .orElseThrow(() -> new RuntimeException("공정을 찾을 수 없습니다. id=" + tradeProcessId));
 
+        authAccessService.assertTradeProcessAccess(tradeProcess);
         plan.linkTradeProcess(tradeProcess);
     }
 
@@ -241,6 +273,7 @@ public class WorkPlanService {
         WorkPlan parent = workPlanRepository.findById(parentWorkPlanId)
                 .orElseThrow(() -> new RuntimeException("상위 작업 계획을 찾을 수 없습니다. id=" + parentWorkPlanId));
 
+        authAccessService.assertWorkPlanAccess(parent);
         plan.linkParentWorkPlan(parent);
     }
 

--- a/src/main/java/org/example/dndn/workplan/model/enums/PlanStatus.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/PlanStatus.java
@@ -17,7 +17,7 @@ public enum PlanStatus {
         }
 
         for (PlanStatus status : values()) {
-            if (status.label.equals(label)) {
+            if (status.label.equals(label) || status.name().equalsIgnoreCase(label)) {
                 return status;
             }
         }

--- a/src/main/java/org/example/dndn/workplan/model/enums/PlanType.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/PlanType.java
@@ -18,7 +18,7 @@ public enum PlanType {
         }
 
         for (PlanType type : values()) {
-            if (type.label.equals(label)) {
+            if (type.label.equals(label) || type.name().equalsIgnoreCase(label)) {
                 return type;
             }
         }

--- a/src/main/java/org/example/dndn/workplan/model/enums/WorkTrade.java
+++ b/src/main/java/org/example/dndn/workplan/model/enums/WorkTrade.java
@@ -28,7 +28,7 @@ public enum WorkTrade {
         }
 
         for (WorkTrade trade : values()) {
-            if (trade.label.equals(label)) {
+            if (trade.label.equals(label) || trade.name().equalsIgnoreCase(label)) {
                 return trade;
             }
         }


### PR DESCRIPTION
## 작업 내용

- 로그인 사용자 권한에 따라 현장 및 공종 접근 범위를 제한하는 `AuthAccessService`를 추가했습니다.
- 현장 총 책임자는 담당 현장의 전체 데이터를 조회할 수 있도록 처리했습니다.
- 공종별 담당자는 본인에게 부여된 공종 데이터만 조회/수정할 수 있도록 제한했습니다.
- 공정계획, 작업지시, 공사일보, 공정분석 관련 API에 현장/공종 권한 필터를 적용했습니다.
- 전체 공정표 화면은 현장 접근 권한만 확인하고 전체 공종을 조회할 수 있도록 예외 처리했습니다.
- 마스터 공정표 재분석 시 기존 추출 공정 및 연결 데이터를 정리한 뒤 새 분석 결과를 저장하도록 수정했습니다.
- 데모 시연용 공정계획/작업지시/공사일보 시드 스크립트를 추가했습니다.

## 주요 변경 사항

- `AuthAccessService` 추가
- `TradeProcess`, `WorkPlan`, `WorkOrder`, `DailyReport`, `Analysis`, `ScheduleChange` 서비스 권한 검증 적용
- 전체 공정표 조회용 `includeAllTrades` 옵션 추가
- 마스터 공정표 재분석 시 기존 `trade_process`, `milestone`, `schedule_ai_analysis` 정리 로직 추가
- 현실형 공정 진행 더미데이터 생성 스크립트 추가